### PR TITLE
Export the pouch so apps that embed express-pouchdb can access this pouc...

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 var express   = require('express')
   , Pouch     = require('pouchdb')
   , fs        = require('fs')
@@ -6,6 +5,8 @@ var express   = require('express')
   , dbs       = {}
   , protocol  = 'leveldb://'
   , app       = module.exports = express();
+
+module.exports.Pouch = Pouch;
 
 // We'll need this for the _all_dbs route.
 Pouch.enableAllDbs = true;


### PR DESCRIPTION
...h.

I have just tried a few different ways of exposing the Pouch instance. This above is successful. Here is how you might use it in an app:

```
var express = require('express'),
    express_pouchdb  = require('express-pouchdb'),
    Pouch = express_pouchdb.Pouch,
    port    = 15984,
    app     = express();

app.use('/_db', express_pouchdb);
app.use(express.static(__dirname + '/public'));
app.listen(port);



Pouch('leveldb://firstPouchapp' , function (err, db) {
    if (err) return console.error('cant init db');
    db.post({name: 'Ryan'}, function(err){

    });
});

```

I have tried the following options, which all failed:
- in express-pouchdb, add app.set('pouchdb', Pouch) but app.get('pouchdb') was unset.
- Add a pouchdb dependency to the app project, and simply require('pouchdb'), but this creates the data files in node_modules/pouchdb/tmp/data and the express app stores the files in the root dir
- require('node_modules/express-pouchdb/node_modules/pouchdb') but like above this stores the files in that folder.

Anyway, the export seems a sane a clean approach.
