### PR TITLE
Allow setting additional PouchDB options on app

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,10 @@ app.put('/:db', function (req, res, next) {
     });
   }
 
-  Pouch(name, function (err, db) {
+  var pouchOpts = app.get('pouchOptions') || {}
+  var dataDir = app.get('dataDirectory') || process.cwd()
+  var path = dataDir + '/' + name
+  Pouch(path, pouchOpts, function (err, db) {
     if (err) return res.send(412, err);
     dbs[name] = db;
     var loc = req.protocol


### PR DESCRIPTION
This combined with https://github.com/daleharvey/pouchdb/pull/1241 is enough to let me use express-pouchdb with MemDOWN and not generate any temporary files on disk. :cool:
