### PR TITLE
(#35) - fix binary attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "pouchdb": "pouchdb/pouchdb"
+    "pouchdb": "pouchdb/pouchdb",
+    "raw-body": "^1.1.5"
   },
   "devDependencies": {
     "express": "4.x",


### PR DESCRIPTION
Every incoming req.body was being coerced to utf-8,
which is not correct for binary attachments.
This adds an extra property, req.rawBody, which
can be used for attachments.
