### PR TITLE
Adds validate_doc_update function support

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,11 +18,17 @@ module.exports = function(PouchToUse) {
   Pouch.plugin(require('pouchdb-list'));
   Pouch.plugin(require('pouchdb-show'));
   Pouch.plugin(require('pouchdb-update'));
+  Pouch.plugin(require('pouchdb-validation'));
   return app;
 };
 
 function isPouchError(obj) {
   return obj.error && obj.error === true;
+}
+
+function registerDB(name, db) {
+  db.installValidationMethods();
+  dbs[name] = db;
 }
 
 function setDBOnReq(db_name, req, res, next) {
@@ -45,7 +51,7 @@ function setDBOnReq(db_name, req, res, next) {
     }
     new Pouch(name, function (err, db) {
       if (err) return res.send(412, err);
-      dbs[name] = db;
+      registerDB(name, db);
       req.db = db;
       return next();
     });
@@ -284,7 +290,7 @@ app.put('/:db', function (req, res, next) {
 
   new Pouch(name, function (err, db) {
     if (err) return res.send(412, err);
-    dbs[name] = db;
+    registerDB(name, db);
     var loc = req.protocol
       + '://'
       + ((req.host === '127.0.0.1') ? '' : req.subdomains.join('.') + '.')

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "pouchdb-show": "^1.0.0",
     "pouchdb-list": "^1.0.0",
     "pouchdb-update": "^1.0.0",
+    "pouchdb-validation": "^1.1.5",
     "raw-body": "^1.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Using the pouchdb-validation plug-in. Passes `npm run pouchdb-test`. Currently just assumes admin party, so only useful for document validation, not user validation. But that can easily be added by supplying the right argument option in the db.put/post/bulkDocs/remove functions when session/security support is added. One downside: every write to the database takes a bit longer because every write needs to check if there are any design documents (which contain the validate_doc_update functions) available. Probably acceptable (CouchDB needs to do it too after all), but worth mentioning.
