### PR TITLE
(#81) - fixes for npm-fullfat-registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "node-uuid": "1.4.1",
+    "bluebird": "^2.2.2",
     "extend": "^1.2.1",
+    "multiparty": "^3.3.1",
+    "node-uuid": "1.4.1",
     "pouchdb-all-dbs": "^0.1.0",
+    "pouchdb-list": "^1.0.0",
     "pouchdb-rewrite": "^1.0.0",
     "pouchdb-show": "^1.0.0",
-    "pouchdb-list": "^1.0.0",
     "pouchdb-update": "^1.0.0",
     "pouchdb-validation": "^1.1.5",
     "raw-body": "^1.1.5"


### PR DESCRIPTION
Notable additions:
- startTime in db.info()
- multipart/related support for PUT
- changes with feed=continuous actually does
  a continuous feed like it's supposed to
