### PR TITLE
(#108) - Adds _replicator database

### DIFF
--- a/lib/couch_config_defaults.js
+++ b/lib/couch_config_defaults.js
@@ -1,6 +1,9 @@
 module.exports = {
   couch_httpd_auth: {
     authentication_db: '_users'
+  },
+  replicator: {
+    db: '_replicator'
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pouchdb-auth": "^1.0.2",
     "pouchdb-all-dbs": "^0.1.0",
     "pouchdb-list": "^1.0.0",
+    "pouchdb-replicator": "^2.0.0",
     "pouchdb-rewrite": "^1.0.0",
     "pouchdb-show": "^1.0.0",
     "pouchdb-update": "^1.0.0",


### PR DESCRIPTION
Adds the ability to persist replications over server restarts.

It's not a perfect clone of the CouchDB replicator yet (create_target only works on http dbs in PouchDB & the retry on error logic isn't the same), but it brings us to the '90%' compatibility level. It should do for now for most use cases. And looking into those two issues is on my todo-list for that plug-in, meaning that it'll probably just work some day without further changes.
