### PR TITLE
(#109) - Adds /_security support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "pouchdb-list": "^1.0.0",
     "pouchdb-replicator": "^2.0.0",
     "pouchdb-rewrite": "^1.0.0",
+    "pouchdb-security": "^1.2.0",
     "pouchdb-show": "^1.0.0",
     "pouchdb-update": "^1.0.0",
     "pouchdb-validation": "^1.1.5",


### PR DESCRIPTION
This completes the work started in #103 and should be enough to close pouchdb/pouchdb-server#32. (Also 'completes' #107, which was already marked fixed).

If there are any authorisation problems left to be found, from this PR onward they're considered bugs by me.

This PR contains a lot of `{req: req}` options objects, if there's a way to get the 'current' request object without passing it in all the time, that would make the code a lot easier to maintain. I've seen some solutions but I doubt they can follow levelup callbacks, without (too much) extra code. Suggestions welcome, although it's not a show stopper.
