### PR TITLE
(#110) - Documents 'non-PouchDB' functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,33 @@ app.use('/db', require('express-pouchdb')(TempPouchDB));
 var myPouch = new TempPouchDB('foo');
 ```
 
+## Functionality
+
+On top of the exposing everything PouchDB offers through a CouchDB-like
+interface, **express-pouchdb** also offers the following extra
+functionality found in CouchDB but not in PouchDB by default:
+
+- [Authentication][] and [authorisation][] support. HTTP basic
+  authentication and cookie authentication are available. Authorisation
+  is handled by [validation functions][] and [security documents][].
+- [Configuration][] support. You can modify configuration values
+  manually in the `config.json` file, or use the HTTP or Fauxton
+  interface.
+- [Replicator database][] support. This allows your replications to
+  persist past a restart of your application.
+- Support for [show], [list] and [update] functions. These allow you to
+  serve non-json content straight from your database.
+
+[authentication]:       http://docs.couchdb.org/en/latest/intro/security.html
+[authorisation]:        http://docs.couchdb.org/en/latest/intro/overview.html#security-and-validation
+[validation functions]: http://docs.couchdb.org/en/latest/couchapp/ddocs.html#vdufun
+[security documents]:   http://docs.couchdb.org/en/latest/api/database/security.html
+[configuration]:        http://docs.couchdb.org/en/latest/config/intro.html#setting-parameters-via-the-http-api
+[replicator database]:  http://docs.couchdb.org/en/latest/replication/replicator.html
+[show]:                 http://guide.couchdb.org/editions/1/en/show.html
+[list]:                 http://guide.couchdb.org/editions/1/en/transforming.html
+[update]:               http://docs.couchdb.org/en/latest/couchapp/ddocs.html#update-functions
+
 ## Contributing
 
 Want to help me make this thing awesome? Great! Here's how you should get started.


### PR DESCRIPTION
Documents a bunch of recently added functionality that's not available in PouchDB by default. Includes links to CouchDB documentation.

[Related comment](https://github.com/pouchdb/express-pouchdb/pull/109#issuecomment-55894446)
