### PR TITLE
proxy is not honored on _replicate requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -570,6 +570,27 @@ app.post('/_replicate', jsonParser, function (req, res, next) {
   if (req.body.filter) opts.filter = req.body.filter;
   if (req.body.query_params) opts.query_params = req.body.query_params;
 
+  var sourceIsHttp = /^http?:\/\//.test(source);
+  var targetIsHttp = /^http?:\/\//.test(target);
+
+  if (sourceIsHttp && targetIsHttp) {
+    sendError(res, {status: 400, message: "Both source and target were http(s), that is not supported."});
+  }
+
+  if (req.body.proxy) {
+    var ajaxOpt = {ajax: {proxy: req.body.proxy}};
+    if (sourceIsHttp) {
+      source = new PouchDB(source, ajaxOpt);
+    }
+
+    if (targetIsHttp) {
+      target = new PouchDB(target, ajaxOpt);
+    }
+
+    // We already checked to make sure that both source and target aren't http and if
+    // neither is HTTP then we will silently ignore the proxy option.
+  }
+
   var startDate = new Date();
   PouchDB.replicate(source, target, opts).then(function (response) {
     
@@ -580,12 +601,12 @@ app.post('/_replicate', jsonParser, function (req, res, next) {
     
     var currentHistories = [];
     
-    if (!/^https?:\/\//.test(source)) {
+    if (!sourceIsHttp) {
       histories[source] = histories[source] || [];
       currentHistories.push(histories[source]);
 
     }
-    if (!/^https?:\/\//.test(target)) {
+    if (!targetIsHttp) {
       histories[target] = histories[target] || [];
       currentHistories.push(histories[target]);
     }

--- a/index.js
+++ b/index.js
@@ -573,10 +573,6 @@ app.post('/_replicate', jsonParser, function (req, res, next) {
   var sourceIsHttp = /^http?:\/\//.test(source);
   var targetIsHttp = /^http?:\/\//.test(target);
 
-  if (sourceIsHttp && targetIsHttp) {
-    sendError(res, {status: 400, message: "Both source and target were http(s), that is not supported."});
-  }
-
   if (req.body.proxy) {
     var ajaxOpt = {ajax: {proxy: req.body.proxy}};
     if (sourceIsHttp) {
@@ -586,9 +582,6 @@ app.post('/_replicate', jsonParser, function (req, res, next) {
     if (targetIsHttp) {
       target = new PouchDB(target, ajaxOpt);
     }
-
-    // We already checked to make sure that both source and target aren't http and if
-    // neither is HTTP then we will silently ignore the proxy option.
   }
 
   var startDate = new Date();


### PR DESCRIPTION
Who cares?
  I'm trying to debug PouchDB's replication behavior versus CouchDB's. I'd like to be able to capture both of their behavior using fiddler so I can easily compare, contrast, etc. The proxy option lets me do that.
  Oh, and it is in the standard and is supported by CouchDB so it's not bad, right?

Why is the change so complicated?
   Because of what I think is a bug in PouchDB, which is that it only honors ajax when you create a new PouchDB object. It really should honor it on replicates too.

Are you sure this code works?
   Heck no! What are we supposed to test this against? A change like this without testing seems rather foolish. So I'm mostly waiting to be told where I should put those tests. I didn't see any in this project. Once it's tested I'll resubmit with both the inevitable bug fixes as well as whatever style guide violations are here fixed.