### PR TITLE
Update sendfile to sendFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -437,7 +437,7 @@ app.all('/_db_updates', requiresServerAdmin, function (req, res, next) {
 });
 
 app.get('/_utils', function (req, res, next) {
-  res.sendfile(__dirname + '/fauxton/index.html');
+  res.sendFile(__dirname + '/fauxton/index.html');
 });
 
 function requiresServerAdmin(req, res, next) {


### PR DESCRIPTION
The lowercase version of sendfile has been deprecated in favor of the upper case version by express. See, for example, [here](http://stackoverflow.com/questions/26202150/express-js-error-express-deprecated-res-sendfile-use-res-sendfile-instead)
