### PR TITLE
(#136) - Add vhosts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ functionality found in CouchDB but not in PouchDB by default:
   interface.
 - [Replicator database][] support. This allows your replications to
   persist past a restart of your application.
-- Support for [show], [list] and [update] functions. These allow you to
-  serve non-json content straight from your database.
+- Support for [show][], [list][] and [update][] functions. These allow
+  you to serve non-json content straight from your database.
+- [Rewrite][] and [Virtual Host][] support, for nicer urls.
 
 [authentication]:       http://docs.couchdb.org/en/latest/intro/security.html
 [authorisation]:        http://docs.couchdb.org/en/latest/intro/overview.html#security-and-validation
@@ -128,6 +129,8 @@ functionality found in CouchDB but not in PouchDB by default:
 [show]:                 http://guide.couchdb.org/editions/1/en/show.html
 [list]:                 http://guide.couchdb.org/editions/1/en/transforming.html
 [update]:               http://docs.couchdb.org/en/latest/couchapp/ddocs.html#update-functions
+[rewrite]:              http://docs.couchdb.org/en/latest/api/ddoc/rewrites.html
+[virtual host]:         http://docs.couchdb.org/en/latest/config/http.html#vhosts
 
 ## Contributing
 

--- a/lib/couch_config_defaults.js
+++ b/lib/couch_config_defaults.js
@@ -6,4 +6,3 @@ module.exports = {
     db: '_replicator'
   }
 };
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,7 @@ function fullServer(PouchDB, app, config, dbWrapper) {
   // load the rules
   utils.loadRoutesIn([
     './routes/auth',
+    './routes/vhosts',
     './routes/rewrite',
     './routes/root',
     './routes/session',

--- a/lib/routes/vhosts.js
+++ b/lib/routes/vhosts.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var utils = require('../utils');
+
+module.exports = function (PouchDB, app, config) {
+  require('pouchdb-vhost')(PouchDB);
+
+  // Query design document rewrite handler
+  app.use(function (req, res, next) {
+    var couchReq = utils.expressReqToCouchDBReq(req);
+    var newUrl = PouchDB.resolveVirtualHost(couchReq, config.getSection('vhosts'));
+
+    if (newUrl !== req.url) {
+      req.url = newUrl;
+      console.log("VirtualHost rewrite to: " + req.url);
+    }
+    next();
+  });
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,7 +70,7 @@ exports.expressReqToCouchDBReq = function (req) {
     cookie: req.cookies || {},
     headers: req.headers,
     method: req.method,
-    path: splitPath(req.originalUrl.split("?")[0]),
+    path: splitPath(req.url.split("?")[0]),
     peer: req.ip,
     query: req.query,
     requested_path: splitPath(req.originalUrl),

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "pouchdb-update": "^1.0.0",
     "pouchdb-validation": "^1.1.5",
     "pouchdb-wrappers": "^1.2.0",
+    "pouchdb-vhost": "^1.0.0",
     "raw-body": "^1.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds support for virtual hosts - together with the already available rewrite support this allows pouchdb-server to serve couchapps with nice urls. They can also be used to hide certain parts of the API.

Uses the brand new [pouchdb-vhost](https://www.npmjs.org/package/pouchdb-vhost) internally.
