### PR TITLE
(#139) - Use mountpoint as rewrite base url

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,6 +65,10 @@ exports.setDBOnReq = function (PouchDB, db_name, dbWrapper, req, res, next) {
 };
 
 exports.expressReqToCouchDBReq = function (req) {
+  var raw_path = req.originalUrl.slice(req.baseUrl.length);
+  if (raw_path[0] !== '/') {
+    raw_path = '/' + raw_path;
+  }
   return exports.makeOpts(req, {
     body: req.rawBody ? req.rawBody.toString() : "undefined",
     cookie: req.cookies || {},
@@ -73,8 +77,8 @@ exports.expressReqToCouchDBReq = function (req) {
     path: splitPath(req.url.split("?")[0]),
     peer: req.ip,
     query: req.query,
-    requested_path: splitPath(req.originalUrl),
-    raw_path: req.originalUrl,
+    requested_path: splitPath(raw_path),
+    raw_path: raw_path,
   });
 };
 


### PR DESCRIPTION
Simply makes all couch-like features think that the mountpoint of the express-pouchdb app is '/'. Tested using a couchapp that the vhost functionality still works.
