### PR TITLE
(pouchdb/pouchdb-server#72) - Reintroduce app.couchConfig

### DIFF
--- a/lib/couch_config.js
+++ b/lib/couch_config.js
@@ -5,7 +5,6 @@ var fs       = require('fs'),
     util     = require('util'),
     events   = require('events'),
     extend   = require('extend'),
-    defaults = require('./couch_config_defaults'),
     Auth     = require('pouchdb-auth');
 
 function CouchConfig(file, hashAdminPasswords) {
@@ -14,6 +13,7 @@ function CouchConfig(file, hashAdminPasswords) {
   this._file = file;
   this._tempFile = path.dirname(this._file) + '/.' + path.basename(this._file);
   this._config = readConfig(this._file);
+  this._defaults = {};
 
   // Hashes admin passwords in 'file' (if necessary)
   this._save();
@@ -59,8 +59,8 @@ CouchConfig.prototype.get = function (section, key) {
     return this._config[section][key];
   } else {
     // fall back on defaults
-    if (defaults[section] && defaults[section][key]) {
-      return defaults[section][key];
+    if (this._defaults[section] && this._defaults[section][key]) {
+      return this._defaults[section][key];
     } else {
       return undefined;
     }
@@ -68,11 +68,11 @@ CouchConfig.prototype.get = function (section, key) {
 };
 
 CouchConfig.prototype.getAll = function () {
-  return extend(true, {}, defaults, this._config);
+  return extend(true, {}, this._defaults, this._config);
 };
 
 CouchConfig.prototype.getSection = function (section) {
-  return extend(true, {}, defaults[section], this._config[section]);
+  return extend(true, {}, this._defaults[section], this._config[section]);
 };
 
 CouchConfig.prototype.set = function (section, key, value, callback) {
@@ -112,4 +112,9 @@ CouchConfig.prototype.delete = function (section, key, callback) {
   }
 
   this._changed(section, key, previousValue, callback);
+};
+
+CouchConfig.prototype.registerDefault = function (section, key, value) {
+  this._defaults[section] = this._defaults[section] || {};
+  this._defaults[section][key] = value;
 };

--- a/lib/couch_config_defaults.js
+++ b/lib/couch_config_defaults.js
@@ -1,8 +1,0 @@
-module.exports = {
-  couch_httpd_auth: {
-    authentication_db: '_users'
-  },
-  replicator: {
-    db: '_replicator'
-  }
-};

--- a/lib/disk_size.js
+++ b/lib/disk_size.js
@@ -1,8 +1,8 @@
 "use strict";
 
-module.exports = function enableDiskSize(PouchDB, app, config, dbWrapper) {
+module.exports = function enableDiskSize(app, PouchDB) {
   PouchDB.plugin(require('pouchdb-size'));
-  dbWrapper.registerWrapper(function (name, db, next) {
+  app.dbWrapper.registerWrapper(function (name, db, next) {
     db.installSizeWrapper();
     return next();
   });

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,18 +4,22 @@ var utils            = require('./utils'),
     enableReplicator = require('./replicator'),
     enableValidation = require('./validation'),
     enableDiskSize   = require('./disk_size'),
-    wrappers         = require('pouchdb-wrappers');
+    wrappers         = require('pouchdb-wrappers'),
+    express          = require('express'),
+    CouchConfig      = require('./couch_config'),
+    DatabaseWrapper  = require('./db_wrapper');
 
-function fullServer(PouchDB, app, config, dbWrapper) {
+function fullServer(PouchDB, opts) {
+  var app = express();
+  app.opts = opts || {};
+  app.couchConfig = new CouchConfig(app.opts.configPath || './config.json');
+  app.dbWrapper = new DatabaseWrapper();
+
   // add PouchDB.new() - by default it just returns 'new PouchDB()'
   wrappers.installStaticWrapperMethods(PouchDB, {});
   require('pouchdb-all-dbs')(PouchDB);
 
-  app = utils.getApp(app);
-  config = utils.getConfig(config);
-  dbWrapper = utils.getDBWrapper(dbWrapper);
-
-  dbWrapper.registerWrapper(function (name, db, next) {
+  app.dbWrapper.registerWrapper(function (name, db, next) {
     //'fix' the PouchDB api (support opts arg everywhere)
     function noop(orig, args) {
       return orig();
@@ -41,8 +45,8 @@ function fullServer(PouchDB, app, config, dbWrapper) {
     next();
   });
 
-  enableDiskSize(PouchDB, app, config, dbWrapper);
-  enableReplicator(PouchDB, app, config, dbWrapper);
+  enableDiskSize(app, PouchDB);
+  enableReplicator(app, PouchDB);
 
   // load the rules
   utils.loadRoutesIn([
@@ -70,9 +74,9 @@ function fullServer(PouchDB, app, config, dbWrapper) {
     './routes/update',
     './routes/attachments',
     './routes/documents'
-  ], PouchDB, app, config, dbWrapper);
+  ], app, PouchDB);
 
-  enableValidation(PouchDB, app, config, dbWrapper);
+  enableValidation(app, PouchDB);
 
   // 404 handler
   app.use(function (req, res, next) {

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -2,15 +2,16 @@
 
 var db, starting;
 
-module.exports = function enableReplicator(PouchDB, app, config, dbWrapper) {
+module.exports = function enableReplicator(app, PouchDB) {
   PouchDB.plugin(require('pouchdb-replicator'));
+  app.couchConfig.registerDefault('replicator', 'db', '_replicator');
 
   function getReplicatorDBName() {
-    return config.get('replicator', 'db');
+    return app.couchConfig.get('replicator', 'db');
   }
 
   // explain how to activate the replicator db logic.
-  dbWrapper.registerWrapper(function (name, db, next) {
+  app.dbWrapper.registerWrapper(function (name, db, next) {
     if (name === getReplicatorDBName()) {
       return db.useAsReplicatorDB();
     }
@@ -26,7 +27,7 @@ module.exports = function enableReplicator(PouchDB, app, config, dbWrapper) {
   }
   startReplicatorDaemon();
 
-  config.on('replicator.db', function () {
+  app.couchConfig.on('replicator.db', function () {
     starting.then(function () {
       //stop old replicator daemon
       db.stopReplicatorDaemon();

--- a/lib/routes/all_dbs.js
+++ b/lib/routes/all_dbs.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app, PouchDB) {
   // List all databases.
   app.get('/_all_dbs', function (req, res, next) {
     PouchDB.allDbs(function (err, response) {

--- a/lib/routes/all_docs.js
+++ b/lib/routes/all_docs.js
@@ -3,7 +3,7 @@
 var utils  = require('../utils'),
     extend = require('extend');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   // All docs operations
   app.all('/:db/_all_docs', utils.jsonParser, function (req, res, next) {
     if (req.method !== 'GET' && req.method !== 'POST') {

--- a/lib/routes/attachments.js
+++ b/lib/routes/attachments.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   // Put a document attachment
   function putAttachment(db, name, req, res) {
     var attachment = req.params.attachment,

--- a/lib/routes/auth.js
+++ b/lib/routes/auth.js
@@ -6,13 +6,17 @@ var cookieParser = require('cookie-parser'),
     uuids        = require('../uuids'),
     Promise      = require('bluebird');
 
-module.exports = function (PouchDB, app, config, dbWrapper) {
+var SECTION = 'couch_httpd_auth';
+var KEY = 'authentication_db';
+
+module.exports = function (app, PouchDB) {
   var usersDBPromise;
 
   PouchDB.plugin(require('pouchdb-auth'));
+  app.couchConfig.registerDefault(SECTION, KEY, '_users');
 
   // explain how to activate the auth db logic.
-  dbWrapper.registerWrapper(function (name, db, next) {
+  app.dbWrapper.registerWrapper(function (name, db, next) {
     if (name === getUsersDBName()) {
       return db.useAsAuthenticationDB();
     }
@@ -20,16 +24,15 @@ module.exports = function (PouchDB, app, config, dbWrapper) {
   });
 
   // utils
-  var getUsersDBName = utils.getUsersDBName.bind(null, config);
-  var getUsersDB = utils.getUsersDB.bind(null, PouchDB, config, dbWrapper);
+  var getUsersDBName = utils.getUsersDBName.bind(null, app);
 
   function refreshUsersDB() {
-    usersDBPromise = getUsersDB();
+    usersDBPromise = utils.getUsersDB(app, PouchDB);
   }
 
   // ensure there's always a users db
   refreshUsersDB();
-  config.on('couch_httpd_auth.authentication_db', refreshUsersDB);
+  app.couchConfig.on(SECTION + '.' + KEY, refreshUsersDB);
   PouchDB.on('destroyed', function (dbName) {
     // if the users db was removed, it should re-appear.
     if (dbName === getUsersDBName()) {
@@ -58,7 +61,7 @@ module.exports = function (PouchDB, app, config, dbWrapper) {
   function buildCookieSession(req) {
     var opts = {
       sessionID: (req.cookies || {}).AuthSession,
-      admins: config.getSection("admins")
+      admins: app.couchConfig.getSection("admins")
     };
     if (!opts.sessionID) {
       throw new Error("No cookie, so no cookie auth.");
@@ -77,7 +80,7 @@ module.exports = function (PouchDB, app, config, dbWrapper) {
     var userInfo = basicAuth(req);
     var opts = {
       sessionID: uuids(1)[0],
-      admins: config.getSection("admins")
+      admins: app.couchConfig.getSection("admins")
     };
     var db;
     var initializingDone = usersDBPromise.then(function (theDB) {

--- a/lib/routes/bulk_docs.js
+++ b/lib/routes/bulk_docs.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   // Bulk docs operations
   app.post('/:db/_bulk_docs', utils.jsonParser, function (req, res, next) {
 

--- a/lib/routes/changes.js
+++ b/lib/routes/changes.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   // Monitor database changes
   function changes(req, res, next) {
 

--- a/lib/routes/compact.js
+++ b/lib/routes/compact.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   // DB Compaction
   app.post('/:db/_compact', utils.jsonParser, function (req, res, next) {
     req.db.compact(utils.makeOpts(req), function (err, response) {

--- a/lib/routes/config.js
+++ b/lib/routes/config.js
@@ -2,18 +2,18 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app, config) {
+module.exports = function (app) {
   // Config
   app.get('/_config', function (req, res, next) {
-    utils.sendJSON(res, 200, config.getAll());
+    utils.sendJSON(res, 200, app.couchConfig.getAll());
   });
 
   app.get('/_config/:section', function (req, res, next) {
-    utils.sendJSON(res, 200, config.getSection(req.params.section));
+    utils.sendJSON(res, 200, app.couchConfig.getSection(req.params.section));
   });
 
   app.get('/_config/:section/:key', function (req, res, next) {
-    var value = config.get(req.params.section, req.params.key);
+    var value = app.couchConfig.get(req.params.section, req.params.key);
     sendConfigValue(res, value);
   });
 
@@ -46,12 +46,14 @@ module.exports = function (PouchDB, app, config) {
     function cb(err, oldValue) {
       utils.sendJSON(res, 200, oldValue || "");
     }
-    config.set(req.params.section, req.params.key, value, cb);
+    app.couchConfig.set(req.params.section, req.params.key, value, cb);
   }
   app.put('/_config/:section/:key', utils.parseRawBody, putHandler);
 
   app.delete('/_config/:section/:key', function (req, res, next) {
-    config.delete(req.params.section, req.params.key, function (err, oldValue) {
+    var section = req.params.section;
+    var key = req.params.key;
+    app.couchConfig.delete(section, key, function (err, oldValue) {
       sendConfigValue(res, oldValue);
     });
   });

--- a/lib/routes/db.js
+++ b/lib/routes/db.js
@@ -3,7 +3,7 @@
 var startTime = new Date().getTime(),
     utils     = require('../utils');
 
-module.exports = function (PouchDB, app, config, dbWrapper) {
+module.exports = function (app, PouchDB) {
   // Create a database.
   app.put('/:db', utils.jsonParser, function (req, res, next) {
     var name = encodeURIComponent(req.params.db);
@@ -48,7 +48,7 @@ module.exports = function (PouchDB, app, config, dbWrapper) {
   // correct PouchDB instance.
   ['/:db/*', '/:db'].forEach(function (route) {
     app.all(route, function (req, res, next) {
-      utils.setDBOnReq(PouchDB, req.params.db, dbWrapper, req, res, next);
+      utils.setDBOnReq(PouchDB, req.params.db, app.dbWrapper, req, res, next);
     });
   });
 

--- a/lib/routes/ddoc_info.js
+++ b/lib/routes/ddoc_info.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   // Query design document info
   app.get('/:db/_design/:id/_info', function (req, res, next) {
     // Dummy data for Fauxton - when implementing fully also take into

--- a/lib/routes/documents.js
+++ b/lib/routes/documents.js
@@ -7,7 +7,7 @@ var fs         = require('fs'),
     extend     = require('extend'),
     Promise    = require('bluebird');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   // Create or update document that has an ID
   app.put('/:db/:id(*)', utils.jsonParser, function (req, res, next) {
 

--- a/lib/routes/fauxton.js
+++ b/lib/routes/fauxton.js
@@ -3,7 +3,7 @@
 var express = require('express');
 var path = require('path');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   app.use('/js', express.static(__dirname + '/../../fauxton/js'));
   app.use('/css', express.static(__dirname + '/../../fauxton/css'));
   app.use('/img', express.static(__dirname + '/../../fauxton/img'));

--- a/lib/routes/list.js
+++ b/lib/routes/list.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app, PouchDB) {
   PouchDB.plugin(require('pouchdb-list'));
 
   // Query design document list handler

--- a/lib/routes/replicate.js
+++ b/lib/routes/replicate.js
@@ -3,7 +3,7 @@
 var utils  = require('../utils'),
     extend = require('extend');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app, PouchDB) {
   var histories = {};
 
   // Replicate a database

--- a/lib/routes/revs_diff.js
+++ b/lib/routes/revs_diff.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   // Revs Diff
   app.post('/:db/_revs_diff', utils.jsonParser, function (req, res, next) {
     req.db.revsDiff(req.body || {}, utils.makeOpts(req), function (err, diffs) {

--- a/lib/routes/rewrite.js
+++ b/lib/routes/rewrite.js
@@ -3,7 +3,7 @@
 var utils = require('../utils');
 var REGEX = /\/([^\/]*)\/_design\/([^\/]*)\/_rewrite\/([^?]*)/;
 
-module.exports = function (PouchDB, app, config, dbWrapper) {
+module.exports = function (app, PouchDB) {
   PouchDB.plugin(require('pouchdb-rewrite'));
 
   // Query design document rewrite handler
@@ -15,7 +15,7 @@ module.exports = function (PouchDB, app, config, dbWrapper) {
     if (!match) {
       return next();
     }
-    utils.setDBOnReq(PouchDB, match[1], dbWrapper, req, res, function () {
+    utils.setDBOnReq(PouchDB, match[1], app.dbWrapper, req, res, function () {
       var query = match[2] + "/" + match[3];
       var opts = utils.expressReqToCouchDBReq(req);
       // We don't know opts.path yet - that's the point.

--- a/lib/routes/root.js
+++ b/lib/routes/root.js
@@ -4,7 +4,7 @@ var pkg    = require('../../package'),
     events = require('events'),
     utils  = require('../utils');
 
-module.exports = function (PouchDB, app, config) {
+module.exports = function (app, PouchDB) {
   // init DbUpdates
   var couchDbUpdates = new events.EventEmitter();
 

--- a/lib/routes/security.js
+++ b/lib/routes/security.js
@@ -3,11 +3,11 @@
 var Security = require('pouchdb-security');
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app, config, dbWrapper) {
+module.exports = function (app, PouchDB) {
   PouchDB.plugin(Security);
   Security.installStaticSecurityMethods(PouchDB);
 
-  dbWrapper.registerWrapper(function (name, db, next) {
+  app.dbWrapper.registerWrapper(function (name, db, next) {
     db.installSecurityMethods();
     return next();
   });

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -3,10 +3,10 @@
 var utils = require('../utils'),
     uuids = require('../uuids');
 
-module.exports = function (PouchDB, app, config, dbWrapper) {
+module.exports = function (app, PouchDB) {
   //depends on auth.js
 
-  var getUsersDB = utils.getUsersDB.bind(null, PouchDB, config, dbWrapper);
+  var getUsersDB = utils.getUsersDB.bind(null, app, PouchDB);
 
   app.get('/_session', function (req, res, next) {
     utils.sendJSON(res, 200, req.couchSession);
@@ -17,7 +17,7 @@ module.exports = function (PouchDB, app, config, dbWrapper) {
     var password = req.body.password;
     var opts = {
       sessionID: uuids(1)[0],
-      admins: config.getSection("admins")
+      admins: app.couchConfig.getSection("admins")
     };
     getUsersDB().then(function (db) {
       return db.logIn(name, password, opts);

--- a/lib/routes/show.js
+++ b/lib/routes/show.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app, PouchDB) {
   PouchDB.plugin(require('pouchdb-show'));
 
   // Query design document show handler

--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app, PouchDB) {
   PouchDB.plugin(require('pouchdb-update'));
 
   // Query design document update handler

--- a/lib/routes/uuids.js
+++ b/lib/routes/uuids.js
@@ -3,7 +3,7 @@
 var utils = require('../utils'),
     uuids = require('../uuids');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   // Generate UUIDs
   app.all('/_uuids', utils.restrictMethods(["GET"]), function (req, res, next) {
     res.set({

--- a/lib/routes/vhosts.js
+++ b/lib/routes/vhosts.js
@@ -2,13 +2,13 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app, config) {
+module.exports = function (app, PouchDB) {
   require('pouchdb-vhost')(PouchDB);
 
   // Query design document rewrite handler
   app.use(function (req, res, next) {
     var couchReq = utils.expressReqToCouchDBReq(req);
-    var vhosts = config.getSection('vhosts');
+    var vhosts = app.couchConfig.getSection('vhosts');
     var newUrl = PouchDB.resolveVirtualHost(couchReq, vhosts);
 
     if (newUrl !== req.url) {

--- a/lib/routes/views.js
+++ b/lib/routes/views.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 
-module.exports = function (PouchDB, app) {
+module.exports = function (app) {
   // Temp Views
   app.post('/:db/_temp_view', utils.jsonParser, function (req, res, next) {
     /*jshint evil: true*/

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,30 +1,15 @@
 "use strict";
 
-var rawBody         = require('raw-body'),
-    express         = require('express'),
-    CouchConfig     = require('./couch_config'),
-    DatabaseWrapper = require('./db_wrapper');
+var rawBody = require('raw-body');
 
 //shared middleware
 exports.jsonParser = require('body-parser').json({limit: '1mb'});
 exports.urlencodedParser = require('body-parser').urlencoded({extended: false});
 
 //helpers
-exports.getApp = function (app) {
-  return app || express();
-};
-
-exports.getConfig = function (config) {
-  return config || new CouchConfig('./config.json');
-};
-
-exports.getDBWrapper = function (dbWrapper) {
-  return dbWrapper || new DatabaseWrapper();
-};
-
-exports.loadRoutesIn = function (paths, PouchDB, app, config, dbWrapper) {
+exports.loadRoutesIn = function (paths, app, PouchDB) {
   paths.forEach(function (path) {
-    require(path)(PouchDB, app, config, dbWrapper);
+    require(path)(app, PouchDB);
   });
 };
 
@@ -37,8 +22,8 @@ exports.makeOpts = function (req, startOpts) {
   return opts;
 };
 
-exports.setDBOnReq = function (PouchDB, db_name, dbWrapper, req, res, next) {
-  var name = encodeURIComponent(db_name);
+exports.setDBOnReq = function (PouchDB, dbName, dbWrapper, req, res, next) {
+  var name = encodeURIComponent(dbName);
 
   PouchDB.allDbs(function (err, dbs) {
     if (err) {
@@ -184,11 +169,11 @@ exports.parseRawBody = function (req, res, next) {
   });
 };
 
-exports.getUsersDBName = function (config) {
-  return config.get('couch_httpd_auth', 'authentication_db');
+exports.getUsersDBName = function (app) {
+  return app.couchConfig.get('couch_httpd_auth', 'authentication_db');
 };
 
-exports.getUsersDB = function (PouchDB, config, dbWrapper) {
-  var name = exports.getUsersDBName(config);
-  return dbWrapper.wrap(name, new PouchDB(name));
+exports.getUsersDB = function (app, PouchDB) {
+  var name = exports.getUsersDBName(app);
+  return app.dbWrapper.wrap(name, new PouchDB(name));
 };

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,9 +1,9 @@
 "use strict";
 
-module.exports = function enableValidation(PouchDB, app, config, dbWrapper) {
+module.exports = function enableValidation(app, PouchDB) {
   PouchDB.plugin(require('pouchdb-validation'));
 
-  dbWrapper.registerWrapper(function (name, db, next) {
+  app.dbWrapper.registerWrapper(function (name, db, next) {
     db.installValidationMethods();
 
     next();

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "express": "^4.8.0"
   },
   "scripts": {
-    "jshint": "jshint -c .jshintrc lib lib/routes test",
+    "jshint": "jshint -c .jshintrc lib test",
     "test-pouchdb": "cd node_modules/pouchdb-server && npm run test-pouchdb",
     "test-couchdb": "cd node_modules/pouchdb-server && npm run test-couchdb",
     "test-express-pouchdb": "./node_modules/.bin/mocha",

--- a/test/test.js
+++ b/test/test.js
@@ -10,21 +10,31 @@ var buildApp = require('..'),
 
 var TEST_DATA = __dirname + '/testdata/';
 
-var expressApp;
+var expressApp, expressApp2;
 
 before(function (done) {
   fse.remove(TEST_DATA, function (err) {
     if (err) {
       return done(err);
     }
-    fse.mkdir(TEST_DATA, function (err) {
+    fse.mkdirs(TEST_DATA + 'a', function (err) {
       if (err) {
         return done(err);
       }
-      expressApp = buildApp(PouchDB.defaults({
-        prefix: TEST_DATA
-      }));
-      done();
+      fse.mkdirs(TEST_DATA + 'b', function (err) {
+        if (err) {
+          return done(err);
+        }
+        expressApp = buildApp(PouchDB.defaults({
+          prefix: TEST_DATA + 'a/'
+        }));
+        expressApp2 = buildApp(PouchDB.defaults({
+          prefix: TEST_DATA + 'b/',
+        }), {
+          configPath: TEST_DATA + 'b-config.json'
+        });
+        done();
+      });
     });
   });
 });
@@ -51,5 +61,65 @@ prefixes.forEach(function (prefix) {
         })
         .end(done);
     });
+  });
+});
+
+describe('config', function () {
+  it('should have ./config.json as default config path', function (done) {
+    fse.exists('./config.json', function (exists) {
+      if (!exists) {
+        return done(new Error("config.json doesn't exist!"));
+      }
+      done();
+    });
+  });
+  it('should support setting a different config path', function (done) {
+    fse.exists(TEST_DATA + 'b-config.json', function (exists) {
+      if (!exists) {
+        return done(new Error("b-config.json doesn't exist!"));
+      }
+      done();
+    });
+  });
+  it('should support externally adding a default', function (done) {
+    expressApp.couchConfig.registerDefault('a', 'b', 'c');
+    request(expressApp)
+      .get('/_config')
+      .expect(200)
+      .expect(function (res) {
+        var a = JSON.parse(res.text).a;
+        if (!(typeof a === "object" && a.b === "c")) {
+          return "Default not shown";
+        }
+      })
+      .end(done);
+  });
+  it('should support externally getting a config value', function (done) {
+    request(expressApp)
+      .put('/_config/test/a')
+      .send('"b"')
+      .expect(200)
+      .end(function () {
+        if (expressApp.couchConfig.get('test', 'a') !== 'b') {
+          return done(new Error("Can't read setting that's just been set"));
+        }
+        done();
+      });
+  });
+  it('should support external listeners to a config change', function (done) {
+    var changed = false;
+    expressApp.couchConfig.on('test2.a', function () {
+      changed = true;
+    });
+    request(expressApp)
+      .put('/_config/test2/a')
+      .send('"b"')
+      .expect(200)
+      .expect(function (res) {
+        if (!changed) {
+          return "Didn't get notice of the setting change";
+        }
+      })
+      .end(done);
   });
 });


### PR DESCRIPTION
Alright, so this reverts some over eager refactoring that we're not going to need now that express-pouchdb will likely stay one package (although that package will provide a way to select which parts of it is enabled, see #122). Doing so, app.couchConfig is reintroduced which is a first step to fixing pouchdb/pouchdb-server#72.

Based on #143 so tests could be added for express-pouchdb's API (which CouchDB doesn't share, of course).
