### PR TITLE
(#145) - remove phantom/firefox from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ env:
 matrix:
   allow_failures:
   - env: COMMAND=test-couchdb
-  - env: CLIENT=selenium:firefox COMMAND=test-pouchdb
-  - env: CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test-pouchdb
 
 branches:
   only:


### PR DESCRIPTION
These seem to finally be passing, and yes, Phantom is ACTUALLY being run. :)
