### PR TITLE
(pouchdb/pouchb-server#72) - change PouchDB on the fly

### DIFF
--- a/lib/daemon_manager.js
+++ b/lib/daemon_manager.js
@@ -1,0 +1,34 @@
+"use strict";
+
+var Promise = require('bluebird');
+
+function DaemonManager() {
+  // There are a few things express-pouchdb needs to do outside of
+  // requests. These things can't get a PouchDB object from the request
+  // like other code does. Instead, they register themselves here and
+  // get an object passed in. By providing both a start and stop
+  // function, it is possible to switch PouchDB objects on the fly.
+  this._daemons = [];
+}
+
+DaemonManager.prototype.registerDaemon = function (daemon) {
+  this._daemons.push(daemon);
+};
+
+['start', 'stop'].forEach(function (name) {
+  DaemonManager.prototype[name] = function (PouchDB) {
+    var promises = this._daemons.map(function (daemon) {
+      return Promise.resolve().then(function () {
+        if (daemon[name]) {
+          return daemon[name](PouchDB);
+        }
+      });
+    });
+
+    return Promise.all(promises).then(function () {
+      // don't resolve to a specific value
+    });
+  };
+});
+
+module.exports = DaemonManager;

--- a/lib/db_wrapper.js
+++ b/lib/db_wrapper.js
@@ -18,21 +18,8 @@ DatabaseWrapper.prototype.wrap = function (name, db) {
   if (typeof db === 'undefined') {
     throw new Error("no db defined!");
   }
-  var self = this;
-
-  var i = 0;
-  function next() {
-    var wrapper = self._wrappers[i];
-    var result = Promise.resolve();
-    if (typeof wrapper !== 'undefined') {
-      i += 1;
-      result = result.then(function () {
-        return wrapper(name, db, next);
-      });
-    }
-    return result;
-  }
-  return next().then(function () {
+  var promise = callInInterruptableChain(this._wrappers, [name, db]);
+  return promise.then(function () {
     return db;
   });
 };
@@ -40,3 +27,20 @@ DatabaseWrapper.prototype.wrap = function (name, db) {
 DatabaseWrapper.prototype.registerWrapper = function (wrapper) {
   this._wrappers.push(wrapper);
 };
+
+function callInInterruptableChain(funcs, args) {
+  var i = 0;
+  function next() {
+    var func = funcs[i];
+    var result = Promise.resolve();
+    if (typeof func !== 'undefined') {
+      i += 1;
+      result = result.then(function () {
+        return func.apply(null, args);
+      });
+    }
+    return result;
+  }
+  args.push(next);
+  return next();
+}

--- a/lib/disk_size.js
+++ b/lib/disk_size.js
@@ -1,7 +1,11 @@
 "use strict";
 
 module.exports = function enableDiskSize(app, PouchDB) {
-  PouchDB.plugin(require('pouchdb-size'));
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      PouchDB.plugin(require('pouchdb-size'));
+    }
+  });
   app.dbWrapper.registerWrapper(function (name, db, next) {
     db.installSizeWrapper();
     return next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,17 +7,48 @@ var utils            = require('./utils'),
     wrappers         = require('pouchdb-wrappers'),
     express          = require('express'),
     CouchConfig      = require('./couch_config'),
-    DatabaseWrapper  = require('./db_wrapper');
+    DatabaseWrapper  = require('./db_wrapper'),
+    DaemonManager    = require('./daemon_manager'),
+    Promise          = require('bluebird');
 
-function fullServer(PouchDB, opts) {
+function fullServer(startPouchDB, opts) {
+  var currentPouchDB;
+
+  // both PouchDB and opts are optional
+  if (startPouchDB && !startPouchDB.defaults) {
+    opts = startPouchDB;
+    startPouchDB = null;
+  }
+  if (!opts) {
+    opts = {};
+  }
+
   var app = express();
-  app.opts = opts || {};
-  app.couchConfig = new CouchConfig(app.opts.configPath || './config.json');
+  app.couchConfig = new CouchConfig(opts.configPath || './config.json');
   app.dbWrapper = new DatabaseWrapper();
 
-  // add PouchDB.new() - by default it just returns 'new PouchDB()'
-  wrappers.installStaticWrapperMethods(PouchDB, {});
-  require('pouchdb-all-dbs')(PouchDB);
+  app.daemonManager = new DaemonManager();
+  app.setPouchDB = function (newPouchDB) {
+    var oldPouchDB = currentPouchDB;
+    currentPouchDB = newPouchDB;
+
+    var stoppingDone = Promise.resolve();
+    if (oldPouchDB) {
+      stoppingDone = app.daemonManager.stop(oldPouchDB);
+    }
+    return stoppingDone.then(function () {
+      return app.daemonManager.start(newPouchDB);
+    });
+  };
+
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      require('pouchdb-all-dbs')(PouchDB);
+
+      // add PouchDB.new() - by default it just returns 'new PouchDB()'
+      wrappers.installStaticWrapperMethods(PouchDB, {});
+    }
+  });
 
   app.dbWrapper.registerWrapper(function (name, db, next) {
     //'fix' the PouchDB api (support opts arg everywhere)
@@ -42,15 +73,24 @@ function fullServer(PouchDB, opts) {
         } catch (e) {}
       }
     }
+
+    // Provide the request access to the current PouchDB object.
+    if (!currentPouchDB) {
+      var msg = "express-pouchdb needs a PouchDB object to route a request!";
+      throw new Error(msg);
+    }
+    req.PouchDB = currentPouchDB;
+
     next();
   });
 
-  enableDiskSize(app, PouchDB);
-  enableReplicator(app, PouchDB);
+  enableDiskSize(app);
+  enableReplicator(app);
 
   // load the rules
   utils.loadRoutesIn([
-    './routes/auth',
+    './routes/authentication',
+    './routes/authorization',
     './routes/vhosts',
     './routes/rewrite',
     './routes/root',
@@ -74,9 +114,9 @@ function fullServer(PouchDB, opts) {
     './routes/update',
     './routes/attachments',
     './routes/documents'
-  ], app, PouchDB);
+  ], app);
 
-  enableValidation(app, PouchDB);
+  enableValidation(app);
 
   // 404 handler
   app.use(function (req, res, next) {
@@ -85,6 +125,10 @@ function fullServer(PouchDB, opts) {
       reason: "missing"
     });
   });
+
+  if (startPouchDB) {
+    app.setPouchDB(startPouchDB);
+  }
 
   return app;
 }

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1,14 +1,9 @@
 "use strict";
 
-var db, starting;
+var Promise = require('bluebird');
 
-module.exports = function enableReplicator(app, PouchDB) {
-  PouchDB.plugin(require('pouchdb-replicator'));
-  app.couchConfig.registerDefault('replicator', 'db', '_replicator');
-
-  function getReplicatorDBName() {
-    return app.couchConfig.get('replicator', 'db');
-  }
+module.exports = function enableReplicator(app) {
+  var db, PouchDB;
 
   // explain how to activate the replicator db logic.
   app.dbWrapper.registerWrapper(function (name, db, next) {
@@ -18,28 +13,61 @@ module.exports = function enableReplicator(app, PouchDB) {
     return next();
   });
 
-  // the following code makes sure there's always a replicator db
-  function startReplicatorDaemon() {
-    var name = getReplicatorDBName();
-    db = new PouchDB(name);
-
-    starting = db.startReplicatorDaemon();
+  app.couchConfig.registerDefault('replicator', 'db', '_replicator');
+  function getReplicatorDBName() {
+    return app.couchConfig.get('replicator', 'db');
   }
-  startReplicatorDaemon();
 
-  app.couchConfig.on('replicator.db', function () {
-    starting.then(function () {
-      //stop old replicator daemon
-      db.stopReplicatorDaemon();
-      //start the new one
-      startReplicatorDaemon();
-    });
-  });
+  app.couchConfig.on('replicator.db', restartDaemon);
 
-  PouchDB.on('destroyed', function (dbName) {
+  function onDestroy(dbName) {
     // if the replicator db was removed, it should re-appear.
     if (dbName === getReplicatorDBName()) {
-      startReplicatorDaemon();
+      restartDaemon();
     }
-  });
+  }
+
+  function restartDaemon() {
+    return daemon.stop().then(function () {
+      return daemon.start();
+    });
+  }
+
+  var currentActions = Promise.resolve();
+  function serialExecution(func) {
+    currentActions = currentActions.then(func);
+    return currentActions;
+  }
+
+  var daemon = {
+    start: function (thePouchDB) {
+      return serialExecution(function () {
+        if (thePouchDB) {
+          PouchDB = thePouchDB;
+
+          PouchDB.plugin(require('pouchdb-replicator'));
+        }
+
+        var name = getReplicatorDBName();
+        db = new PouchDB(name);
+
+        PouchDB.on('destroyed', onDestroy);
+        return db.startReplicatorDaemon();
+      });
+    },
+    stop: function () {
+      return serialExecution(function () {
+        PouchDB.removeListener('destroyed', onDestroy);
+        // stop old replicator daemon
+        return Promise.resolve().then(function () {
+          return db.stopReplicatorDaemon();
+        }).catch(function () {
+          // no worries if stopping failed, the database is probably
+          // just not there (or deleted).
+        });
+      });
+    }
+  };
+
+  app.daemonManager.registerDaemon(daemon);
 };

--- a/lib/routes/all_dbs.js
+++ b/lib/routes/all_dbs.js
@@ -2,10 +2,10 @@
 
 var utils = require('../utils');
 
-module.exports = function (app, PouchDB) {
+module.exports = function (app) {
   // List all databases.
   app.get('/_all_dbs', function (req, res, next) {
-    PouchDB.allDbs(function (err, response) {
+    req.PouchDB.allDbs(function (err, response) {
       if (err) {
         return utils.sendError(res, err);
       }

--- a/lib/routes/authentication.js
+++ b/lib/routes/authentication.js
@@ -9,10 +9,9 @@ var cookieParser = require('cookie-parser'),
 var SECTION = 'couch_httpd_auth';
 var KEY = 'authentication_db';
 
-module.exports = function (app, PouchDB) {
-  var usersDBPromise;
+module.exports = function (app) {
+  var usersDBPromise, refreshUsersDBImpl;
 
-  PouchDB.plugin(require('pouchdb-auth'));
   app.couchConfig.registerDefault(SECTION, KEY, '_users');
 
   // explain how to activate the auth db logic.
@@ -23,22 +22,37 @@ module.exports = function (app, PouchDB) {
     return next();
   });
 
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      PouchDB.plugin(require('pouchdb-auth'));
+
+      refreshUsersDBImpl = function () {
+        usersDBPromise = utils.getUsersDB(app, PouchDB);
+      };
+      refreshUsersDB();
+      PouchDB.on('destroyed', onDestroyed);
+    },
+    stop: function (PouchDB) {
+      PouchDB.removeListener('destroyed', onDestroyed);
+    }
+  });
+
   // utils
   var getUsersDBName = utils.getUsersDBName.bind(null, app);
 
-  function refreshUsersDB() {
-    usersDBPromise = utils.getUsersDB(app, PouchDB);
-  }
-
-  // ensure there's always a users db
-  refreshUsersDB();
-  app.couchConfig.on(SECTION + '.' + KEY, refreshUsersDB);
-  PouchDB.on('destroyed', function (dbName) {
+  function onDestroyed(dbName) {
     // if the users db was removed, it should re-appear.
     if (dbName === getUsersDBName()) {
       refreshUsersDB();
     }
-  });
+  }
+
+  function refreshUsersDB() {
+    return refreshUsersDBImpl();
+  }
+
+  // ensure there's always a users db
+  app.couchConfig.on(SECTION + '.' + KEY, refreshUsersDB);
 
   // routing
   app.use(cookieParser());
@@ -104,27 +118,6 @@ module.exports = function (app, PouchDB) {
         result.info.authenticated = 'default';
       }
       return result;
-    });
-  }
-
-  // routes that need server admin protection
-  app.get('/_config', requiresServerAdmin);
-  app.get('/_config/:section', requiresServerAdmin);
-  app.get('/_config/:section/:key', requiresServerAdmin);
-  app.put('/_config/:section/:key', requiresServerAdmin);
-  app.delete('/_config/:section/:key', requiresServerAdmin);
-
-  app.get('/_log', requiresServerAdmin);
-  app.get('/_active_tasks', requiresServerAdmin);
-  app.get('/_db_updates', requiresServerAdmin);
-
-  function requiresServerAdmin(req, res, next) {
-    if (req.couchSession.userCtx.roles.indexOf('_admin') !== -1) {
-      return next();
-    }
-    utils.sendJSON(res, 401, {
-      error: 'unauthorized',
-      reason: "You are not a server admin."
     });
   }
 };

--- a/lib/routes/authorization.js
+++ b/lib/routes/authorization.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var utils = require('../utils');
+
+module.exports = function (app) {
+  // routes that need server admin protection
+  app.get('/_config', requiresServerAdmin);
+  app.get('/_config/:section', requiresServerAdmin);
+  app.get('/_config/:section/:key', requiresServerAdmin);
+  app.put('/_config/:section/:key', requiresServerAdmin);
+  app.delete('/_config/:section/:key', requiresServerAdmin);
+
+  app.get('/_log', requiresServerAdmin);
+  app.get('/_active_tasks', requiresServerAdmin);
+  app.get('/_db_updates', requiresServerAdmin);
+  app.post('/_restart', requiresServerAdmin);
+
+  function requiresServerAdmin(req, res, next) {
+    if (req.couchSession.userCtx.roles.indexOf('_admin') !== -1) {
+      return next();
+    }
+    utils.sendJSON(res, 401, {
+      error: 'unauthorized',
+      reason: "You are not a server admin."
+    });
+  }
+};

--- a/lib/routes/db.js
+++ b/lib/routes/db.js
@@ -3,12 +3,12 @@
 var startTime = new Date().getTime(),
     utils     = require('../utils');
 
-module.exports = function (app, PouchDB) {
+module.exports = function (app) {
   // Create a database.
   app.put('/:db', utils.jsonParser, function (req, res, next) {
     var name = encodeURIComponent(req.params.db);
 
-    PouchDB.allDbs(function (err, dbs) {
+    req.PouchDB.allDbs(function (err, dbs) {
       if (err) {
         return utils.sendError(res, err);
       }
@@ -22,7 +22,7 @@ module.exports = function (app, PouchDB) {
 
       // PouchDB.new() instead of new PouchDB() because that adds
       // authorisation logic
-      PouchDB.new(name, utils.makeOpts(req), function (err, db) {
+      req.PouchDB.new(name, utils.makeOpts(req), function (err, db) {
         if (err) {
           return utils.sendError(res, err, 412);
         }
@@ -35,7 +35,7 @@ module.exports = function (app, PouchDB) {
   // Delete a database
   app.delete('/:db', function (req, res, next) {
     var name = encodeURIComponent(req.params.db);
-    PouchDB.destroy(name, utils.makeOpts(req), function (err, info) {
+    req.PouchDB.destroy(name, utils.makeOpts(req), function (err, info) {
       if (err) {
         return utils.sendError(res, err);
       }
@@ -48,7 +48,7 @@ module.exports = function (app, PouchDB) {
   // correct PouchDB instance.
   ['/:db/*', '/:db'].forEach(function (route) {
     app.all(route, function (req, res, next) {
-      utils.setDBOnReq(PouchDB, req.params.db, app.dbWrapper, req, res, next);
+      utils.setDBOnReq(req.params.db, app.dbWrapper, req, res, next);
     });
   });
 

--- a/lib/routes/list.js
+++ b/lib/routes/list.js
@@ -2,8 +2,12 @@
 
 var utils = require('../utils');
 
-module.exports = function (app, PouchDB) {
-  PouchDB.plugin(require('pouchdb-list'));
+module.exports = function (app) {
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      PouchDB.plugin(require('pouchdb-list'));
+    }
+  });
 
   // Query design document list handler
   function handler(req, res, next) {

--- a/lib/routes/replicate.js
+++ b/lib/routes/replicate.js
@@ -3,7 +3,7 @@
 var utils  = require('../utils'),
     extend = require('extend');
 
-module.exports = function (app, PouchDB) {
+module.exports = function (app) {
   var histories = {};
 
   // Replicate a database
@@ -21,7 +21,7 @@ module.exports = function (app, PouchDB) {
     }
 
     var startDate = new Date();
-    PouchDB.replicate(source, target, opts).then(function (response) {
+    req.PouchDB.replicate(source, target, opts).then(function (response) {
 
       var historyObj = extend(true, {
         start_time: startDate.toJSON(),
@@ -57,7 +57,7 @@ module.exports = function (app, PouchDB) {
 
     // if continuous pull replication return 'ok' since we cannot wait
     // for callback
-    PouchDB.allDbs(function (err, dbs) {
+    req.PouchDB.allDbs(function (err, dbs) {
       if (err) {
         return utils.sendError(res, err);
       }

--- a/lib/routes/rewrite.js
+++ b/lib/routes/rewrite.js
@@ -3,8 +3,12 @@
 var utils = require('../utils');
 var REGEX = /\/([^\/]*)\/_design\/([^\/]*)\/_rewrite\/([^?]*)/;
 
-module.exports = function (app, PouchDB) {
-  PouchDB.plugin(require('pouchdb-rewrite'));
+module.exports = function (app) {
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      PouchDB.plugin(require('pouchdb-rewrite'));
+    }
+  });
 
   // Query design document rewrite handler
   app.use(function (req, res, next) {
@@ -15,7 +19,7 @@ module.exports = function (app, PouchDB) {
     if (!match) {
       return next();
     }
-    utils.setDBOnReq(PouchDB, match[1], app.dbWrapper, req, res, function () {
+    utils.setDBOnReq(match[1], app.dbWrapper, req, res, function () {
       var query = match[2] + "/" + match[3];
       var opts = utils.expressReqToCouchDBReq(req);
       // We don't know opts.path yet - that's the point.

--- a/lib/routes/root.js
+++ b/lib/routes/root.js
@@ -4,16 +4,25 @@ var pkg    = require('../../package'),
     events = require('events'),
     utils  = require('../utils');
 
-module.exports = function (app, PouchDB) {
+module.exports = function (app) {
   // init DbUpdates
   var couchDbUpdates = new events.EventEmitter();
 
-  PouchDB.on('created', function (dbName) {
+  function onDBCreated(dbName) {
     couchDbUpdates.emit('update', {db_name: dbName, type: 'created'});
-  });
-
-  PouchDB.on('destroyed', function (dbName) {
+  }
+  function onDBDestroyed(dbName) {
     couchDbUpdates.emit('update', {db_name: dbName, type: 'deleted'});
+  }
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      PouchDB.on('created', onDBCreated);
+      PouchDB.on('destroyed', onDBDestroyed);
+    },
+    stop: function (PouchDB) {
+      PouchDB.removeListener('created', onDBCreated);
+      PouchDB.removeListener('destroyed', onDBDestroyed);
+    }
   });
 
   // Routing

--- a/lib/routes/security.js
+++ b/lib/routes/security.js
@@ -3,9 +3,13 @@
 var Security = require('pouchdb-security');
 var utils = require('../utils');
 
-module.exports = function (app, PouchDB) {
-  PouchDB.plugin(Security);
-  Security.installStaticSecurityMethods(PouchDB);
+module.exports = function (app) {
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      PouchDB.plugin(Security);
+      Security.installStaticSecurityMethods(PouchDB);
+    }
+  });
 
   app.dbWrapper.registerWrapper(function (name, db, next) {
     db.installSecurityMethods();

--- a/lib/routes/session.js
+++ b/lib/routes/session.js
@@ -3,10 +3,12 @@
 var utils = require('../utils'),
     uuids = require('../uuids');
 
-module.exports = function (app, PouchDB) {
+module.exports = function (app) {
   //depends on auth.js
 
-  var getUsersDB = utils.getUsersDB.bind(null, app, PouchDB);
+  function getUsersDB(req) {
+    return utils.getUsersDB(app, req.PouchDB);
+  }
 
   app.get('/_session', function (req, res, next) {
     utils.sendJSON(res, 200, req.couchSession);
@@ -19,7 +21,7 @@ module.exports = function (app, PouchDB) {
       sessionID: uuids(1)[0],
       admins: app.couchConfig.getSection("admins")
     };
-    getUsersDB().then(function (db) {
+    getUsersDB(req).then(function (db) {
       return db.logIn(name, password, opts);
     }).then(function (resp) {
       res.cookie('AuthSession', opts.sessionID, {httpOnly: true});
@@ -33,7 +35,7 @@ module.exports = function (app, PouchDB) {
   app.delete('/_session', function (req, res, next) {
     var sessionID = (req.cookies || {}).AuthSession;
 
-    getUsersDB().then(function (db) {
+    getUsersDB(req).then(function (db) {
       //no error handler necessary for log out
       return db.logOut({sessionID: sessionID});
     }).then(function (resp) {

--- a/lib/routes/show.js
+++ b/lib/routes/show.js
@@ -2,8 +2,12 @@
 
 var utils = require('../utils');
 
-module.exports = function (app, PouchDB) {
-  PouchDB.plugin(require('pouchdb-show'));
+module.exports = function (app) {
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      PouchDB.plugin(require('pouchdb-show'));
+    }
+  });
 
   // Query design document show handler
   function handler(req, res, next) {

--- a/lib/routes/update.js
+++ b/lib/routes/update.js
@@ -2,8 +2,12 @@
 
 var utils = require('../utils');
 
-module.exports = function (app, PouchDB) {
-  PouchDB.plugin(require('pouchdb-update'));
+module.exports = function (app) {
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      PouchDB.plugin(require('pouchdb-update'));
+    }
+  });
 
   // Query design document update handler
   app.all(

--- a/lib/routes/vhosts.js
+++ b/lib/routes/vhosts.js
@@ -2,14 +2,18 @@
 
 var utils = require('../utils');
 
-module.exports = function (app, PouchDB) {
-  require('pouchdb-vhost')(PouchDB);
+module.exports = function (app) {
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      require('pouchdb-vhost')(PouchDB);
+    }
+  });
 
   // Query design document rewrite handler
   app.use(function (req, res, next) {
     var couchReq = utils.expressReqToCouchDBReq(req);
     var vhosts = app.couchConfig.getSection('vhosts');
-    var newUrl = PouchDB.resolveVirtualHost(couchReq, vhosts);
+    var newUrl = req.PouchDB.resolveVirtualHost(couchReq, vhosts);
 
     if (newUrl !== req.url) {
       req.url = newUrl;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,9 +7,9 @@ exports.jsonParser = require('body-parser').json({limit: '1mb'});
 exports.urlencodedParser = require('body-parser').urlencoded({extended: false});
 
 //helpers
-exports.loadRoutesIn = function (paths, app, PouchDB) {
+exports.loadRoutesIn = function (paths, app) {
   paths.forEach(function (path) {
-    require(path)(app, PouchDB);
+    require(path)(app);
   });
 };
 
@@ -22,10 +22,10 @@ exports.makeOpts = function (req, startOpts) {
   return opts;
 };
 
-exports.setDBOnReq = function (PouchDB, dbName, dbWrapper, req, res, next) {
+exports.setDBOnReq = function (dbName, dbWrapper, req, res, next) {
   var name = encodeURIComponent(dbName);
 
-  PouchDB.allDbs(function (err, dbs) {
+  req.PouchDB.allDbs(function (err, dbs) {
     if (err) {
       return exports.sendError(res, err);
     }
@@ -36,7 +36,7 @@ exports.setDBOnReq = function (PouchDB, dbName, dbWrapper, req, res, next) {
         reason: 'no_db_file'
       });
     }
-    new PouchDB(name, function (err, db) {
+    new req.PouchDB(name, function (err, db) {
       if (err) {
         return exports.sendError(res, err, 412);
       }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,7 +1,11 @@
 "use strict";
 
-module.exports = function enableValidation(app, PouchDB) {
-  PouchDB.plugin(require('pouchdb-validation'));
+module.exports = function enableValidation(app) {
+  app.daemonManager.registerDaemon({
+    start: function (PouchDB) {
+      PouchDB.plugin(require('pouchdb-validation'));
+    }
+  });
 
   app.dbWrapper.registerWrapper(function (name, db, next) {
     db.installValidationMethods();


### PR DESCRIPTION
pouchdb/pouchdb-server#72 needs this for two reasons:
1) when the couchdb.database_dir config option changes, it needs to update to the new value without a restart.
2) when starting, it needs to be able to access app.couchConfig for default values for its command line arguments before creating the PouchDB object.
