### PR TITLE
(#150) - remove express peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "pouchdb-server": "^0.4.0",
     "supertest": "^0.15.0"
   },
-  "peerDependencies": {
-    "express": "^4.8.0"
-  },
   "scripts": {
     "jshint": "jshint -c .jshintrc lib test",
     "test-pouchdb": "cd node_modules/pouchdb-server && npm run test-pouchdb",


### PR DESCRIPTION
So apparently peer deps are weird, and `^4.8.0` is not the same as `>=4.8.0`, because now it's working for me with express 4.10.
