### PR TITLE
(pouchdb/pouchdb-server#67) - Support http-pouchdb objects 

### DIFF
--- a/lib/daemon-manager.js
+++ b/lib/daemon-manager.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var Promise = require('bluebird');
+var utils = require('./utils');
 
 function DaemonManager() {
   // There are a few things express-pouchdb needs to do outside of
@@ -17,16 +18,13 @@ DaemonManager.prototype.registerDaemon = function (daemon) {
 
 ['start', 'stop'].forEach(function (name) {
   DaemonManager.prototype[name] = function (PouchDB) {
-    var promises = this._daemons.map(function (daemon) {
-      return Promise.resolve().then(function () {
-        if (daemon[name]) {
-          return daemon[name](PouchDB);
-        }
-      });
+    var funcs = this._daemons.map(function (daemon) {
+      return daemon[name];
     });
-
-    return Promise.all(promises).then(function () {
-      // don't resolve to a specific value
+    return utils.callAsyncRecursive(funcs, function (func, next) {
+      return Promise.resolve().then(function () {
+        return func(PouchDB);
+      }).then(next);
     });
   };
 });

--- a/lib/db-wrapper.js
+++ b/lib/db-wrapper.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var Promise = require('bluebird');
+var utils = require('./utils');
 
 function DatabaseWrapper() {
   // Databases can be wrapped to let them provide extra functionality.
@@ -18,8 +19,13 @@ DatabaseWrapper.prototype.wrap = function (name, db) {
   if (typeof db === 'undefined') {
     throw new Error("no db defined!");
   }
-  var promise = callInInterruptableChain(this._wrappers, [name, db]);
-  return promise.then(function () {
+  return utils.callAsyncRecursive(this._wrappers, function (wrapper, next) {
+    return Promise.resolve().then(function () {
+      return wrapper(name, db, next);
+    });
+  }).then(function () {
+    // https://github.com/pouchdb/pouchdb/issues/1940
+    delete db.then;
     return db;
   });
 };
@@ -27,20 +33,3 @@ DatabaseWrapper.prototype.wrap = function (name, db) {
 DatabaseWrapper.prototype.registerWrapper = function (wrapper) {
   this._wrappers.push(wrapper);
 };
-
-function callInInterruptableChain(funcs, args) {
-  var i = 0;
-  function next() {
-    var func = funcs[i];
-    var result = Promise.resolve();
-    if (typeof func !== 'undefined') {
-      i += 1;
-      result = result.then(function () {
-        return func.apply(null, args);
-      });
-    }
-    return result;
-  }
-  args.push(next);
-  return next();
-}

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,10 +123,14 @@ module.exports = function (startPouchDB, opts) {
 
   app.daemonManager.registerDaemon({
     start: function (PouchDB) {
-      require('pouchdb-all-dbs')(PouchDB);
-
       // add PouchDB.new() - by default it just returns 'new PouchDB()'
       wrappers.installStaticWrapperMethods(PouchDB, {});
+
+      return Promise.resolve().then(function () {
+        return PouchDB.allDbs();
+      }).catch(function () {
+        require('pouchdb-all-dbs')(PouchDB);
+      });
     }
   });
 

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -44,13 +44,16 @@ module.exports = function enableReplicator(app) {
 
   var daemon = {
     start: function (thePouchDB) {
+      if (thePouchDB) {
+        PouchDB = thePouchDB;
+
+        PouchDB.plugin(require('pouchdb-replicator'));
+      }
+      if (PouchDB.isHTTPPouchDB) {
+        return;
+      }
+
       return serialExecution(function () {
-        if (thePouchDB) {
-          PouchDB = thePouchDB;
-
-          PouchDB.plugin(require('pouchdb-replicator'));
-        }
-
         var name = getReplicatorDBName();
         db = new PouchDB(name);
 
@@ -59,6 +62,9 @@ module.exports = function enableReplicator(app) {
       });
     },
     stop: function () {
+      if (PouchDB.isHTTPPouchDB) {
+        return;
+      }
       return serialExecution(function () {
         PouchDB.removeListener('destroyed', onDestroy);
         // stop old replicator daemon

--- a/lib/routes/authentication.js
+++ b/lib/routes/authentication.js
@@ -43,6 +43,17 @@ module.exports = function (app) {
   // utils
   var getUsersDBName = utils.getUsersDBName.bind(null, app);
 
+  function getUsersDB() {
+    if (!usersDBPromise) {
+      return new Promise(function (resolve) {
+        setImmediate(function () {
+          resolve(getUsersDB());
+        });
+      });
+    }
+    return usersDBPromise;
+  }
+
   function onDestroyed(dbName) {
     // if the users db was removed, it should re-appear.
     if (dbName === getUsersDBName()) {
@@ -83,7 +94,7 @@ module.exports = function (app) {
     if (!opts.sessionID) {
       throw new Error("No cookie, so no cookie auth.");
     }
-    return usersDBPromise.then(function (db) {
+    return getUsersDB().then(function (db) {
       return db.session(opts);
     }).then(function (result) {
       if (result.info.authenticated) {
@@ -106,7 +117,7 @@ module.exports = function (app) {
       admins: app.couchConfig.getSection("admins")
     };
     var db;
-    var initializingDone = usersDBPromise.then(function (theDB) {
+    var initializingDone = getUsersDB().then(function (theDB) {
       db = theDB;
     });
     if (userInfo) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var rawBody = require('raw-body');
+var Promise = require('bluebird');
 
 //shared middleware
 var jsonParser = require('body-parser').json({limit: '1mb'});
@@ -201,3 +202,15 @@ exports.requires = function (app, part) {
   }
 };
 
+exports.callAsyncRecursive = function (funcs, handleCall) {
+  var i = 0;
+  function next() {
+    var func = funcs[i];
+    if (typeof func === 'undefined') {
+      return Promise.resolve();
+    }
+    i++;
+    return handleCall(func, next);
+  }
+  return next();
+};


### PR DESCRIPTION
Based on top of the profiles PR (#155) to hopefully prevent conflicts.

The changes necessary to support a proxying pouchdb-server. (Which uses [http-pouchdb](https://www.npmjs.com/package/http-pouchdb).)