### PR TITLE
(#177) - Changes couchdb-harness fixes

### DIFF
--- a/lib/routes/changes.js
+++ b/lib/routes/changes.js
@@ -90,13 +90,11 @@ module.exports = function (app) {
         });
       }
     } else { // straight shot, not continuous
-      req.query.complete = function (err, response) {
-        if (err) {
-          return utils.sendError(res, err);
-        }
+      req.db.changes(req.query).then(function (response) {
         utils.sendJSON(res, 200, response);
-      };
-      req.db.changes(req.query);
+      }).catch(function (err) {
+        utils.sendError(res, err);
+      });
     }
   }
   app.get('/:db/_changes', changes);


### PR DESCRIPTION
Makes sure that errors in changes() are caught by express-pouchdb. (Found while working on couchdb-harness, the errors where validly generated by the pouchdb-security wrapper IIRC.)