### PR TITLE
(pouchdb/pouchdb#3872) - fix getAttachment with rev

### DIFF
--- a/lib/routes/attachments.js
+++ b/lib/routes/attachments.js
@@ -59,7 +59,7 @@ module.exports = function (app) {
       var type = info._attachments[attachment].content_type;
       var md5 = info._attachments[attachment].digest.slice(4);
 
-      req.db.getAttachment(name, attachment, function (err, response) {
+      req.db.getAttachment(name, attachment, opts, function (err, response) {
         if (err) {
           return utils.sendError(res, err);
         }


### PR DESCRIPTION
This is required for both pouchdb/pouchdb#3870
and pouchdb/pouchdb#3872 to pass.