### PR TITLE
(#2832) - don't store 'follows' key for multipart

### DIFF
--- a/lib/routes/documents.js
+++ b/lib/routes/documents.js
@@ -47,6 +47,10 @@ module.exports = function (app) {
         });
       }).on('close', function () {
         promise.then(function () {
+          // don't store the "follows" key
+          Object.keys(doc._attachments).forEach(function (filename) {
+            delete doc._attachments[filename].follows;
+          });
           // merge, since it could be a mix of stubs and non-stubs
           doc._attachments = extend(true, doc._attachments, attachments);
           req.db.put(doc, opts, onResponse);


### PR DESCRIPTION
This is required for pouchdb/pouchdb#3876 to pass.