### PR TITLE
(#225) - actually test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,6 @@ before_script:
     # Workaround for Selenium #3280 issue
   - "sudo sed -i 's/^127\\.0\\.0\\.1.*$/127.0.0.1 localhost/' /etc/hosts"
 
-    # pouchdb-server setup
-  - "rm -fr node_modules/pouchdb-server/node_modules/express-pouchdb"
-  - "ln -s ../../.. node_modules/pouchdb-server/node_modules/express-pouchdb"
-  - "cd node_modules/pouchdb-server && npm install && cd -"
-
-    # pouchdb setup
-  - "ln -s ../../.. node_modules/pouchdb/node_modules/express-pouchdb"
-  - "ln -s ../../pouchdb-server node_modules/pouchdb/node_modules/pouchdb-server"
-  - "cd node_modules/pouchdb && npm install && cd -"
-
 script: "npm run $COMMAND"
 
 env:

--- a/bin/express-pouchdb-minimum-for-pouchdb.js
+++ b/bin/express-pouchdb-minimum-for-pouchdb.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var PouchDB = require('../node_modules/pouchdb');
+
+var app = require('../')(PouchDB, {
+  mode: 'minimumForPouchDB'
+});
+app.listen(6984);

--- a/bin/test-pouchdb-minimum.sh
+++ b/bin/test-pouchdb-minimum.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+node ./bin/express-pouchdb-minimum-for-pouchdb.js &
+POUCHDB_SERVER_PID=$!
+
+cd ./node_modules/pouchdb
+
+COUCH_HOST=http://127.0.0.1:6984 npm test
+
+EXIT_STATUS=$?
+if [[ ! -z $POUCHDB_SERVER_PID ]]; then
+  kill $POUCHDB_SERVER_PID
+fi
+exit $EXIT_STATUS

--- a/bin/test-pouchdb.sh
+++ b/bin/test-pouchdb.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cd node_modules/pouchdb-server
+
+./bin/pouchdb-server -p 6984 $SERVER_ARGS &
+POUCHDB_SERVER_PID=$!
+
+cd ../pouchdb
+
+COUCH_HOST=http://127.0.0.1:6984 npm test
+
+EXIT_STATUS=$?
+if [[ ! -z $POUCHDB_SERVER_PID ]]; then
+  kill $POUCHDB_SERVER_PID
+fi
+exit $EXIT_STATUS

--- a/bin/test-setup.sh
+++ b/bin/test-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# link pouchdb back to us
+cd node_modules/pouchdb
+npm install
+cd node_modules/pouchdb-server/node_modules
+rm -fr express-pouchdb
+ln -s ../../../../.. express-pouchdb
+cd ../../../../..
+
+# link pouchdb-server back to us
+cd node_modules/pouchdb-server
+npm install
+cd node_modules
+rm -fr express-pouchdb
+ln -s ../../.. express-pouchdb
+# link pouchdb-server's pouchdb to the master/master one
+rm -fr pouchdb
+ln -s ../../pouchdb pouchdb
+cd ../../..

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
   },
   "scripts": {
     "jshint": "jshint -c .jshintrc lib test",
-    "test-pouchdb": "cd node_modules/pouchdb-server && npm run test-pouchdb",
-    "test-pouchdb-minimum": "cd node_modules/pouchdb && SERVER=express-pouchdb-minimum npm test",
-    "test-couchdb": "cd node_modules/pouchdb-server && npm run test-couchdb",
+    "test-pouchdb": "./bin/test-setup.sh && ./bin/test-pouchdb.sh",
+    "test-pouchdb-minimum": "./bin/test-setup.sh && ./bin/test-pouchdb-minimum.sh",
+    "test-couchdb": "./bin/test-setup.sh && cd node_modules/pouchdb-server && npm run test-couchdb",
     "test-express-pouchdb": "./node_modules/.bin/mocha",
     "test": "npm run jshint && npm run test-express-pouchdb && npm run test-pouchdb && npm run test-pouchdb-minimum"
   }


### PR DESCRIPTION
So this might fail because there's a bug in PouchDB
3.6.0 and we are now using the npm version of PouchDB
instead of the master version. But I manually verified
that the master version is passing with these changes.

You'll know if the 3.6.0 bug is present because
you'll see an error about the `Buffer` constructor.