### PR TITLE
(#231) - remove PouchDB.destroy usage

### DIFF
--- a/lib/routes/db.js
+++ b/lib/routes/db.js
@@ -46,7 +46,7 @@ module.exports = function (app) {
       });
     }
     var name = encodeURIComponent(req.params.db);
-    req.PouchDB.destroy(name, utils.makeOpts(req), function (err, info) {
+    new req.PouchDB(name, utils.makeOpts(req)).destroy(function (err, info) {
       if (err) {
         return utils.sendError(res, err);
       }


### PR DESCRIPTION
I'm tired of seeing warnings about PouchDB.destroy in the log output.