### PR TITLE
(#200) - allow uploading attachments

### DIFF
--- a/lib/routes/documents.js
+++ b/lib/routes/documents.js
@@ -5,40 +5,113 @@ var fs         = require('fs'),
     utils      = require('../utils'),
     uuids      = require('../uuids'),
     extend     = require('extend'),
-    Promise    = require('bluebird');
+    Promise    = require('bluebird'),
+    readFile   = Promise.promisify(fs.readFile);
+
+function onPutOrPostResponse(req, res) {
+  return function (response) {
+    res.set('ETag', '"' + response.rev + '"');
+    utils.setLocation(res, req.params.db + '/' + response.id);
+    utils.sendJSON(res, 201, response);
+  };
+}
+
+function mergeAttachments(doc, attachments) {
+  if (!doc._attachments) {
+    doc._attachments = {};
+  }
+
+  // don't store the "follows" key
+  Object.keys(doc._attachments).forEach(function (filename) {
+    delete doc._attachments[filename].follows;
+  });
+  // merge, since it could be a mix of stubs and non-stubs
+  doc._attachments = extend(true, doc._attachments, attachments);
+}
 
 module.exports = function (app) {
   utils.requires(app, 'routes/db');
+
+  // Slightly unusual endpoint where you can POST an attachment to a doc.
+  // Used by the Fauxton UI for uploading attachments.
+  app.post('/:db/:id(*)', utils.jsonParser, function (req, res, next) {
+    if (!/^multipart\/form-data/.test(req.headers['content-type'])) {
+      return utils.sendJSON(res, 400, {
+        error: "bad_request",
+        reason: "only_multipart_accepted"
+      });
+    }
+
+    var opts = utils.makeOpts(req, req.query);
+
+    var promise = Promise.resolve();
+    var attachments = {};
+    var form = new multiparty.Form();
+    var doc;
+    form.on('error', function (err) {
+      promise = promise.then(function () {
+        throw err;
+      });
+    }).on('field', function (name, field) {
+      if (name !== '_rev') {
+        return;
+      }
+      promise = promise.then(function () {
+        return req.db.get(req.params.id, {rev: field});
+      }).then(function (theDoc) {
+        doc = theDoc;
+      });
+    }).on('file', function (_, file) {
+      var type = file.headers['content-type'];
+      var filename = file.originalFilename;
+      promise = promise.then(function () {
+        return readFile(file.path);
+      }).then(function (body) {
+        attachments[filename] = {
+          content_type: type,
+          data: body
+        };
+      });
+    }).on('close', function () {
+      promise.then(function () {
+        if (!doc) {
+          var err = new Error('bad_request');
+          err.reason = 'no_doc_provided';
+          err.status = 400;
+          throw err;
+        }
+        mergeAttachments(doc, attachments);
+        return req.db.put(doc, opts);
+      }).then(
+        onPutOrPostResponse(req, res)
+      ).catch(function (err) {
+        utils.sendError(res, err);
+      });
+    });
+    form.parse(req);
+  });
 
   // Create or update document that has an ID
   app.put('/:db/:id(*)', utils.jsonParser, function (req, res, next) {
 
     var opts = utils.makeOpts(req, req.query);
 
-    function onResponse(err, response) {
-      if (err) {
-        return utils.sendError(res, err);
-      }
-      res.set('ETag', '"' + response.rev + '"');
-      utils.setLocation(res, req.params.db + '/' + response.id);
-      utils.sendJSON(res, 201, response);
-    }
-
     if (/^multipart\/related/.test(req.headers['content-type'])) {
-      // multipart, assuming it's also new_edits=false for now
       var doc;
       var promise = Promise.resolve();
       var form = new multiparty.Form();
       var attachments = {};
       form.on('error', function (err) {
-        return utils.sendError(res, err);
+        promise = promise.then(function () {
+          throw err;
+        });
       }).on('field', function (_, field) {
         doc = JSON.parse(field);
       }).on('file', function (_, file) {
         var type = file.headers['content-type'];
         var filename = file.originalFilename;
         promise = promise.then(function () {
-          return Promise.promisify(fs.readFile)(file.path);
+          return readFile(file.path);
         }).then(function (body) {
           attachments[filename] = {
             content_type: type,
@@ -47,14 +120,11 @@ module.exports = function (app) {
         });
       }).on('close', function () {
         promise.then(function () {
-          // don't store the "follows" key
-          Object.keys(doc._attachments).forEach(function (filename) {
-            delete doc._attachments[filename].follows;
-          });
-          // merge, since it could be a mix of stubs and non-stubs
-          doc._attachments = extend(true, doc._attachments, attachments);
-          req.db.put(doc, opts, onResponse);
-        }).catch(function (err) {
+          mergeAttachments(doc, attachments);
+          return req.db.put(doc, opts);
+        }).then(
+          onPutOrPostResponse(req, res)
+        ).catch(function (err) {
           utils.sendError(res, err);
         });
       });
@@ -67,7 +137,11 @@ module.exports = function (app) {
           req.params.id : null;
       }
       req.body._rev = getRev(req, req.body);
-      req.db.put(req.body, opts, onResponse);
+      req.db.put(req.body, opts).then(
+        onPutOrPostResponse(req, res)
+      ).catch(function (err) {
+        utils.sendError(res, err);
+      });
     }
   });
 


### PR DESCRIPTION
This allows the user to upload binary attachments from the
Fauxton UI. There was an endpoint for `multipart/form-data`
that hadn't been implemented.