### PR TITLE
(pouchdb/pouchdb-server#117) - always set content-type

### DIFF
--- a/lib/routes/changes.js
+++ b/lib/routes/changes.js
@@ -8,6 +8,8 @@ module.exports = function (app) {
   // Monitor database changes
   function changes(req, res, next) {
 
+    utils.setJsonOrPlaintext(res);
+
     // api.changes expects a property `query_params`
     // This is a pretty inefficient way to do it.. Revisit?
     req.query.query_params = JSON.parse(JSON.stringify(req.query));
@@ -50,39 +52,32 @@ module.exports = function (app) {
           cleanup();
         });
       } else { // longpoll
-
         // first check if there are >0. if so, return them immediately
         req.query.live = req.query.continuous = false;
-        req.db.changes(req.query).on('complete', function (complete) {
-          if (!complete.results) {
-            // canceled, ignore
-            cleanup();
-          } else if (complete.results.length) {
-            written = true;
+        req.db.changes(req.query).then(function (complete) {
+          if (complete.results.length) {
             utils.writeJSON(res, complete);
             res.end();
             cleanup();
           } else { // do the longpolling
+            // mimicking CouchDB, start sending the JSON immediately
+            res.write('{"results":[\n');
             req.query.live = req.query.continuous = true;
             var changes = req.db.changes(req.query)
               .on('change', function (change) {
-                written = true;
-                utils.writeJSON(res, {
-                  results: [change],
-                  last_seq: change.seq
-                });
+                utils.writeJSON(res, change);
+                res.write('],\n"last_seq":' + change.seq + '}\n');
                 res.end();
                 changes.cancel();
                 cleanup();
-              })
-              .on('error', function (err) {
-                if (!written) {
-                  utils.sendError(res, err);
-                }
+              }).on('error', function (err) {
+                // shouldn't happen
+                console.log(err);
+                res.end();
                 cleanup();
               });
           }
-        }).on('error', function (err) {
+        }, function (err) {
           if (!written) {
             utils.sendError(res, err);
           }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -185,7 +185,7 @@ exports.sendError = function (res, err, baseStatus) {
   exports.sendJSON(res, status, err);
 };
 
-function sendOrWriteJson(res, body, send) {
+function setJsonOrPlaintext(res) {
   // Send the client application/json if they asked for it,
   // else send text/plain; charset=utf-8. This mimics CouchDB.
   var type = res.req.accepts(['text', 'json']);
@@ -195,25 +195,25 @@ function sendOrWriteJson(res, body, send) {
     //adds ; charset=utf-8
     res.type('text/plain');
   }
+}
 
+function jsonToBuffer(body) {
   //convert to buffer so express doesn't add the ; charset=utf-8 if it
   //isn't already there by now. No performance problem: express does
   //this internally anyway.
-  var response = new Buffer(JSON.stringify(body) + "\n", 'utf8');
-  if (send) {
-    res.send(response);
-  } else {
-    res.write(response);
-  }
+  return new Buffer(JSON.stringify(body) + "\n", 'utf8');
 }
 
+exports.setJsonOrPlaintext = setJsonOrPlaintext;
+
 exports.writeJSON = function (res, body) {
-  sendOrWriteJson(res, body, false);
+  res.write(jsonToBuffer(body));
 };
 
 exports.sendJSON = function (res, status, body) {
   res.status(status);
-  sendOrWriteJson(res, body, true);
+  setJsonOrPlaintext(res);
+  res.send(jsonToBuffer(body));
 };
 
 exports.sendCallback = function (res, errCode, successCode) {


### PR DESCRIPTION
Another attempt to fix this bug. More closely mimics the
behavior of CouchDB when `?longpoll=true`.