### PR TITLE
(#265) - return immediately when using opts.continuous

### DIFF
--- a/lib/routes/replicate.js
+++ b/lib/routes/replicate.js
@@ -21,6 +21,7 @@ module.exports = function (app) {
     }
 
     var startDate = new Date();
+    // TODO: actually use the _replicator database
     req.PouchDB.replicate(source, target, opts).then(function (response) {
 
       var historyObj = extend(true, {
@@ -50,22 +51,21 @@ module.exports = function (app) {
       });
 
       response.history = histories[source] || histories[target] || [];
-      utils.sendJSON(res, 200, response);
+      if (!opts.continuous) {
+        utils.sendJSON(res, 200, response);
+      }
     }, function (err) {
-      utils.sendError(res, err);
+      console.log(err);
+      console.log(err.stack);
+      if (!opts.continuous) {
+        utils.sendError(res, err);
+      }
     });
 
     // if continuous pull replication return 'ok' since we cannot wait
     // for callback
-    req.PouchDB.allDbs(function (err, dbs) {
-      if (err) {
-        return utils.sendError(res, err);
-      }
-
-      if (dbs.indexOf(target) !== -1 && opts.continuous) {
-        utils.sendJSON(res, 200, { ok : true });
-      }
-    });
-
+    if (opts.continuous) {
+      utils.sendJSON(res, 200, {ok: true});
+    }
   });
 };


### PR DESCRIPTION
This is mostly to make the Fauxton UI nicer to work with.
As-is, it's not guaranteed to immediately show the
"replication started" message if you use continuous replication.
This fixes that.

A big TODO is to actually use the `_replicator` database,
so that you can see live replication tasks that are in-progress.