### PR TITLE
Added a timeout handler for long polling changes requests in /routes/…

### DIFF
--- a/lib/routes/changes.js
+++ b/lib/routes/changes.js
@@ -21,7 +21,7 @@ module.exports = function (app) {
     }
 
     if (req.query.feed === 'continuous' || req.query.feed === 'longpoll') {
-      var heartbeatInterval;
+      var heartbeatInterval, timeoutHandler;
       // 60000 is the CouchDB default
       // TODO: figure out if we can make this default less aggressive
       var heartbeat = (typeof req.query.heartbeat === 'number') ?
@@ -35,6 +35,9 @@ module.exports = function (app) {
       var cleanup = function () {
         if (heartbeatInterval) {
           clearInterval(heartbeatInterval);
+        }
+        if (timeoutHandler) {
+          clearTimeout(timeoutHandler);
         }
       };
 
@@ -76,6 +79,16 @@ module.exports = function (app) {
                 res.end();
                 cleanup();
               });
+
+            timeoutHandler = req.query.timeout ? setTimeout(
+              function() {
+                res.write('],\n"last_seq":' + req.query.since + '}\n');
+                res.end();
+                changes.cancel();
+                cleanup();
+              }
+              , req.query.timeout
+            ) : null;
           }
         }, function (err) {
           if (!written) {

--- a/lib/routes/changes.js
+++ b/lib/routes/changes.js
@@ -86,8 +86,7 @@ module.exports = function (app) {
                 res.end();
                 changes.cancel();
                 cleanup();
-              }
-              , req.query.timeout
+              }, req.query.timeout
             ) : null;
           }
         }, function (err) {


### PR DESCRIPTION
An invalid json is returned when running express-pouchdb on a server which has a connection timeout (even if data is still being transferred) set. Since the timeout param is ignored it causes express-pouchdb to return an invalid json  result (`{"results":[`) once the connection is closed by the server.

I added a timeout handler for long polling changes requests. This way the timeout param in the request url isn’t ignored any longer and a valid json (`{"results":[],"last_seq":` + req.query.since + `}`) is returned when the timeout param is lower then the connection timeout of the server.
