### PR TITLE
Allow adding plugin to express-pouchdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ is the most important middleware known to be problematic.
   - ``overrideMode``: Sometimes the preprogrammed modes are insufficient for your needs, or you chose the ``'custom'`` mode. In that case, you can set this to an object. This object can have the following properties:
     - ``'include'``: a javascript array that specifies parts to include on top of the ones specified by ``opts.mode``. Optional.
     - ``'exclude'``: a javascript array that specifies parts to exclude from the ones specified by ``opts.mode``. Optional.
+    - ``'plugins'``: a javascript array that specifies nodejs modules to be loaded additional to standard modules. Optional.
 
 The application object returned contains some extra properties that
 offer additional functionality compared to an ordinary express
@@ -111,6 +112,22 @@ var app2 = require('express-pouchdb')(require('pouchdb'), {
       // following parts too. Which makes sense since they depend on it.
       'routes/authorization',
       'routes/session'
+    ]
+  }
+});
+```
+
+#### Example 3
+
+builds a full HTTP API with plugin [express-pouchdb-jwt](https://github.com/siuying/express-pouchdb-jwt)
+for JSON Web Token authentication:
+
+```javascript
+var app3 = require('express-pouchdb')(require('pouchdb'), {
+  mode: 'fullCouchDB',
+  overrideMode: {
+    plugins: [
+      'express-pouchdb-jwt'
     ]
   }
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,6 +113,7 @@ module.exports = function (startPouchDB, opts) {
     }
     delete app.includes[part];
   });
+  app.plugins = opts.overrideMode.plugins;
 
   // the daemon manager is a non-negotiable part of express-pouchdb,
   // it's needed for static method wrappers & installing
@@ -186,14 +187,25 @@ module.exports = function (startPouchDB, opts) {
     next();
   });
 
-  // load all modular files
   [
-    // order matters in this list!
     'config-infrastructure',
     'logging-infrastructure',
     'compression',
     'disk-size',
-    'replicator',
+    'replicator'
+  ].forEach(function (file) {
+    if (app.includes[file]) {
+      require('./' + file)(app);
+    }
+  });
+
+  app.plugins.forEach(function (plugin) {
+    require(plugin)(app)
+  });
+
+  // load all routes
+  [
+    // order matters in this list!
     'routes/http-log',
     'routes/authentication',
     'routes/special-test-auth',
@@ -238,10 +250,6 @@ module.exports = function (startPouchDB, opts) {
     if (app.includes[file]) {
       require('./' + file)(app);
     }
-  });
-
-  opts.overrideMode.plugins.forEach(function (plugin) {
-    require(plugin)(app);
   });
 
   if (app.couchConfig) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ module.exports = function (startPouchDB, opts) {
   opts.overrideMode = opts.overrideMode || {};
   opts.overrideMode.include = opts.overrideMode.include || [];
   opts.overrideMode.exclude = opts.overrideMode.exclude || [];
+  opts.overrideMode.plugins = opts.overrideMode.plugins || [];
   opts.overrideMode.include.forEach(function (part) {
     if (modes.fullCouchDB.indexOf(part) === -1) {
       throw new Error(
@@ -237,6 +238,10 @@ module.exports = function (startPouchDB, opts) {
     if (app.includes[file]) {
       require('./' + file)(app);
     }
+  });
+
+  opts.overrideMode.plugins.forEach(function (plugin) {
+    require(plugin)(app);
   });
 
   if (app.couchConfig) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -200,7 +200,7 @@ module.exports = function (startPouchDB, opts) {
   });
 
   app.plugins.forEach(function (plugin) {
-    require(plugin)(app)
+    require(plugin)(app);
   });
 
   // load all routes


### PR DESCRIPTION
I'm trying to write an extension to allow using JSON Web Token to authenticate access.

The plugin itself is very simple and I can get it work in no time (https://github.com/siuying/express-pouchdb/blob/jwt/lib/routes/jwt.js). But when I try to extract it into separate plugin, they didnt work as expected. 

I think the problem is the plugin needs `config-infrastructure`, and also need to load before remaining routes. I figure having ability to insert plugin into the `express-pouchdb` might be helpful for others as well, would you please see if it is suitable to merge?
