### PR TITLE
(pouchdb/pouchdb#4669) - fix ETags for GET /db/doc

### DIFF
--- a/lib/routes/documents.js
+++ b/lib/routes/documents.js
@@ -219,8 +219,19 @@ module.exports = function (app) {
       if (err) {
         return utils.sendError(res, err);
       }
+      console.log('opts', opts);
+      console.log('doc', doc);
 
-      res.set('ETag', '"' + doc._rev + '"');
+      // We only want to send the ETag if this is a normal GET, like
+      //     GET /db/foo
+      //     GET /db/foo?rev=1-x
+      // and not something with multiple revs like
+      //     GET /db/foo?revs=true&open_revs=all
+      // Because then it will cause the response to be over-cached.
+      var etagRev = doc.rev || doc._rev;
+      if (etagRev) {
+        res.set('ETag', '"' + etagRev + '"');
+      }
       utils.sendJSON(res, 200, doc);
     });
   });


### PR DESCRIPTION
We were sending ETags too frequently, causing Firefox
to over-cache, causing our tests to fail. This should
fix the Firefox tests.