### PR TITLE
(#281) - remove Etag logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
 
   # Test in firefox/phantomjs running on travis
   - CLIENT=selenium:firefox COMMAND=test-pouchdb
-  - CLIENT=selenium:phantomjs ES5_SHIM=true COMMAND=test-pouchdb
+  - CLIENT=selenium:phantomjs COMMAND=test-pouchdb
 
   # Test against the couchdb harness
   - COMMAND=test-couchdb

--- a/lib/routes/documents.js
+++ b/lib/routes/documents.js
@@ -165,36 +165,7 @@ module.exports = function (app) {
   });
 
   function getRev(req, doc) {
-    var docRevExists = typeof doc._rev !== 'undefined';
-    var queryRevExists = typeof req.query.rev !== 'undefined';
-    var etagRevExists = typeof req.get('If-Match') !== 'undefined';
-    if (docRevExists && queryRevExists && doc._rev !== req.query.rev) {
-      return utils.sendJSON(req.res, 400, {
-        error: 'bad_request',
-        reason: (
-          "Document rev from request body and " +
-          "query string have different values"
-        )
-      });
-    }
-    var etagRev;
-    if (etagRevExists) {
-      etagRev = req.get('If-Match').slice(1, -1);
-      if (docRevExists && doc._rev !== etagRev) {
-        return utils.sendJSON(req.res, 400, {
-          error: 'bad_request',
-          reason: "Document rev and etag have different values"
-        });
-      }
-      if (queryRevExists && req.query.rev !== etagRev) {
-        return utils.sendJSON(req.res, 400, {
-          error: 'bad_request',
-          reason: "Document rev and etag have different values"
-        });
-      }
-    }
-
-    return doc._rev || req.query.rev || etagRev;
+    return doc._rev || req.query.rev;
   }
 
   // Create a document
@@ -220,16 +191,6 @@ module.exports = function (app) {
         return utils.sendError(res, err);
       }
 
-      // We only want to send the ETag if this is a normal GET, like
-      //     GET /db/foo
-      //     GET /db/foo?rev=1-x
-      // and not something with multiple revs like
-      //     GET /db/foo?revs=true&open_revs=all
-      // Because then it will cause the response to be over-cached.
-      var etagRev = doc.rev || doc._rev;
-      if (etagRev) {
-        res.set('ETag', '"' + etagRev + '"');
-      }
       utils.sendJSON(res, 200, doc);
     });
   });


### PR DESCRIPTION
This is causing the tests to fail, because the `_rev` is not sufficient to determine the uniqueness of a document.

Really, the ETag should be a function of:

1) the database (e.g. it should change when it's destroyed)
2) the _rev
3) the _revisions object (which can change independently of the _rev due to new_edits=false

I propose that for the time being we just remove this ETag logic in order to get the tests to pass. If we can figure out how to add ETags without breaking the build, then I'll be happy to put them back in, since it's a perf improvement.