### PR TITLE
Adding support for lists with views from other DDocs

### DIFF
--- a/lib/routes/list.js
+++ b/lib/routes/list.js
@@ -13,11 +13,19 @@ module.exports = function (app) {
 
   // Query design document list handler
   function handler(req, res, next) {
-    var query = [req.params.id, req.params.func, req.params.view].join("/");
+    var queryParts = [req.params.id, req.params.func];
+    if ('id2' in req.params) {
+      queryParts.push(req.params.id2);
+    }
+    queryParts.push(req.params.view);
+    var query = queryParts.join("/");
     var cb = utils.sendCouchDBResp.bind(null, res);
     req.db.list(query, req.couchDBReq, cb);
   }
   app.all('/:db/_design/:id/_list/:func/:view',
+    utils.couchDBReqMiddleware, handler
+  );
+  app.all('/:db/_design/:id/_list/:func/:id2/:view',
     utils.couchDBReqMiddleware, handler
   );
 };


### PR DESCRIPTION
According to the official CouchDB documentation, _lists_ also can use views of a secondary, different design document (see http://docs.couchdb.org/en/1.6.1/api/ddoc/render.html#db-design-design-doc-list-list-name-other-ddoc-view-name). 
This pull request together with pouchdb/pouchdb-list#4 fix that issue.