### PR TITLE
Document that pouchdb+express modules be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ which is primarily used as a quick-and-dirty drop-in replacement for CouchDB in 
 ## Installation
 
 ```bash
-$ npm install express-pouchdb
+$ npm install express-pouchdb pouchdb express
 ```
 
 ## Example Usage


### PR DESCRIPTION
`pouchdb` and `express` modules should be installed along the `express-pouchdb` modules to have the most minimal working application, and this is in sync with the "Example Usage".