### PR TITLE
(#326) - Update install and fixed polling problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 node_modules
 test/testdata
+.idea/
+config.json
+log.txt
+*.ldb
+*.log
+CURRENT
+LOCK
+LOG
+MANIFEST-*

--- a/bin/test-pouchdb-minimum.sh
+++ b/bin/test-pouchdb-minimum.sh
@@ -3,7 +3,7 @@
 node ./bin/express-pouchdb-minimum-for-pouchdb.js &
 POUCHDB_SERVER_PID=$!
 
-cd ./node_modules/pouchdb
+cd ./node_modules/pouchdbclone
 
 COUCH_HOST=http://127.0.0.1:6984 npm test
 

--- a/bin/test-pouchdb.sh
+++ b/bin/test-pouchdb.sh
@@ -5,7 +5,7 @@ cd node_modules/pouchdb-server
 ./bin/pouchdb-server -n -p 6984 $SERVER_ARGS &
 POUCHDB_SERVER_PID=$!
 
-cd ../pouchdb
+cd ../pouchdbclone
 
 COUCH_HOST=http://127.0.0.1:6984 npm test
 

--- a/bin/test-setup.sh
+++ b/bin/test-setup.sh
@@ -2,16 +2,24 @@
 
 # install pouchdb from git master rather than npm,
 # so we can run its own tests
-rm -fr node_modules/pouchdb
+rm -fr node_modules/pouchdbclone
 git clone --depth 1 --single-branch --branch master \
-  https://github.com/pouchdb/pouchdb.git node_modules/pouchdb
+  https://github.com/pouchdb/pouchdb.git node_modules/pouchdbclone
 
-cd node_modules/pouchdb/
+cd node_modules/pouchdbclone/
 npm install
+npm build
+cd ../..
+rm -fr node_modules/pouchdb
+ln -s ./pouchdbclone/packages/pouchdb ./node_modules/pouchdb
+cd node_modules/pouchdb
+npm install
+cd ../..
+
 cd node_modules/pouchdb-server/node_modules
 rm -fr express-pouchdb
-ln -s ../../../../.. express-pouchdb
-cd ../../../../..
+ln -s ../../.. express-pouchdb
+cd ../../..
 
 # link pouchdb-server back to us
 cd node_modules/pouchdb-server

--- a/lib/routes/changes.js
+++ b/lib/routes/changes.js
@@ -21,6 +21,7 @@ module.exports = function (app) {
     }
 
     if (req.query.feed === 'continuous' || req.query.feed === 'longpoll') {
+      var changes;
       var heartbeatInterval;
       // 60000 is the CouchDB default
       // TODO: figure out if we can make this default less aggressive
@@ -28,6 +29,10 @@ module.exports = function (app) {
         req.query.heartbeat : 6000;
       var written = false;
       heartbeatInterval = setInterval(function () {
+        if (res.connection.destroyed) {
+          return cleanup();
+        }
+
         written = true;
         res.write('\n');
       }, heartbeat);
@@ -36,19 +41,24 @@ module.exports = function (app) {
         if (heartbeatInterval) {
           clearInterval(heartbeatInterval);
         }
+
+        if (changes) {
+          changes.cancel();
+        }
+
+        res.end();
       };
 
       if (req.query.feed === 'continuous') {
         req.query.live = req.query.continuous = true;
-        req.db.changes(req.query).on('change', function (change) {
+        changes = req.db.changes(req.query).on('change', function (change) {
           written = true;
           utils.writeJSON(res, change);
         }).on('error', function (err) {
           if (!written) {
             utils.sendError(res, err);
-          } else {
-            res.end();
           }
+
           cleanup();
         });
       } else { // longpoll
@@ -57,23 +67,19 @@ module.exports = function (app) {
         req.db.changes(req.query).then(function (complete) {
           if (complete.results.length) {
             utils.writeJSON(res, complete);
-            res.end();
             cleanup();
           } else { // do the longpolling
             // mimicking CouchDB, start sending the JSON immediately
             res.write('{"results":[\n');
             req.query.live = req.query.continuous = true;
-            var changes = req.db.changes(req.query)
+            changes = req.db.changes(req.query)
               .on('change', function (change) {
                 utils.writeJSON(res, change);
                 res.write('],\n"last_seq":' + change.seq + '}\n');
-                res.end();
-                changes.cancel();
                 cleanup();
               }).on('error', function (err) {
                 // shouldn't happen
                 console.log(err);
-                res.end();
                 cleanup();
               });
           }


### PR DESCRIPTION
#326 

.gitignore - A bunch of files it would be good not to check in :)

test-setup.sh - To adapt to the new way of building PouchDB I now clone
PouchDB into its own separate directory, pouchdbclone and then do an
install and build, symbolically link to packages/pouchdb and install that
as well.

test-pouchdb-minimum.sh - The tests (as opposed to the live code) now
lives in pouchdbclone

test-pouchdb.sh - Same as previous

changes - As explained in #326 I tried to hook all the obvious events and
literally nothing fired when a connection was lost. So instead when
the heartbeat runs I check if we have lost the socket and if so then
I clean up. I also made cleanup able to cancel any live changes objects
and call res.end.