### PR TITLE
Update pouchdb-express for PouchDB 5.4

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,15 +71,10 @@ exports.setDBOnReq = function (dbName, dbWrapper, req, res, next) {
         reason: 'no_db_file'
       });
     }
-    new req.PouchDB(encodeURIComponent(dbName), function (err, db) {
-      if (err) {
-        return exports.sendError(res, err, 412);
-      }
-      dbWrapper.wrap(dbName, db).then(function () {
-        req.db = db;
-
-        next();
-      });
+    var db = new req.PouchDB(encodeURIComponent(dbName));
+    dbWrapper.wrap(dbName, db).then(function () {
+      req.db = db;
+      next();
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node-uuid": "1.4.1",
     "on-finished": "2.3.0",
     "pouchdb-all-dbs": "1.0.1",
-    "pouchdb-auth": "2.0.1",
+    "pouchdb-auth": "2.1.0",
     "pouchdb-find": "0.1.0",
     "pouchdb-list": "1.1.0",
     "pouchdb-replicator": "2.1.3",
@@ -44,7 +44,7 @@
     "jshint": "2.9.2",
     "memdown": "1.1.2",
     "mocha": "2.4.5",
-    "pouchdb": "5.3.1",
+    "pouchdb": "5.4.1",
     "pouchdb-server": "1.1.1",
     "supertest": "0.15.0"
   },


### PR DESCRIPTION
Fixes for depreciations and to use new version of our libraries.