### PR TITLE
(#352) - update node-uuid to 1.4.7 for security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "extend": "1.3.0",
     "header-case-normalizer": "1.0.3",
     "multiparty": "3.3.2",
-    "node-uuid": "1.4.1",
+    "node-uuid": "1.4.7",
     "on-finished": "2.3.0",
     "pouchdb-all-dbs": "1.0.2",
     "pouchdb-auth": "2.1.0",


### PR DESCRIPTION
Update [node-uuid](https://github.com/broofa/node-uuid) to v1.4.7 

For https://github.com/pouchdb/express-pouchdb/issues/352

All tests ran with same results before update. 

 - npm run test-pouchdb
 - npm run jshint
 - npm run test-express-pouchdb