### PR TITLE
Fix "req.query.hasOwnProperty is not a function" error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,11 +168,9 @@ module.exports = function (startPouchDB, opts) {
     // Normalize query string parameters for direct passing
     // into PouchDB queries.
     for (prop in req.query) {
-      if (req.query.hasOwnProperty(prop)) {
         try {
           req.query[prop] = JSON.parse(req.query[prop]);
         } catch (e) {}
-      }
     }
 
     // Provide the request access to the current PouchDB object.


### PR DESCRIPTION
`req.query` does not have hasOwnProperty method for a long time: https://github.com/tj/node-querystring/issues/61