### PR TITLE
Fix "req.query.hasOwnProperty is not a function" error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,7 +168,7 @@ module.exports = function (startPouchDB, opts) {
     // Normalize query string parameters for direct passing
     // into PouchDB queries.
     for (prop in req.query) {
-      if (req.query.hasOwnProperty(prop)) {
+      if (Object.prototype.hasOwnProperty.call(req.query, prop)) {
         try {
           req.query[prop] = JSON.parse(req.query[prop]);
         } catch (e) {}


### PR DESCRIPTION
I use `express-pouchdb` through `hoodie` and got this error. I don't exactly understand why is it happening, but I found mentions of this bug in some versions of express. I hope you'll merge it, the changes looks harmless. Thank you :)