### PR TITLE
remove incorret dbname encoding

### DIFF
--- a/bin/test-setup.sh
+++ b/bin/test-setup.sh
@@ -7,7 +7,7 @@ git clone --single-branch --branch master \
   https://github.com/pouchdb/pouchdb.git node_modules/pouchdb
 
 cd node_modules/pouchdb/
-git reset --hard 6a8ac8785
+git reset --hard c3b79b9
 npm install
 cd node_modules/pouchdb-server/node_modules
 rm -fr express-pouchdb

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,9 @@
 "use strict";
 
+var pathResolve = require('path').resolve;
 var rawBody = require('raw-body');
 var Promise = require('bluebird');
+var mkdirp = require('mkdirp');
 
 //shared middleware
 
@@ -71,7 +73,15 @@ exports.setDBOnReq = function (dbName, dbWrapper, req, res, next) {
         reason: 'no_db_file'
       });
     }
-    var db = new req.PouchDB(encodeURIComponent(dbName));
+    var db = new req.PouchDB(dbName);
+
+    // temporary workaround for https://github.com/pouchdb/pouchdb/issues/5668
+    // see also https://github.com/pouchdb/express-pouchdb/issues/274
+    if (/\//.test(dbName)) {
+      var path = db.__opts.prefix ? db.__opts.prefix + dbName : dbName;
+      mkdirp.sync(pathResolve(path));
+    }
+
     dbWrapper.wrap(dbName, db).then(function () {
       req.db = db;
       next();

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "jshint": "~2.8.0",
     "memdown": "1.1.2",
     "mocha": "2.5.3",
-    "pouchdb": "~5.4.1",
-    "pouchdb-node": "^5.4.4",
+    "pouchdb": "^6.0.4",
+    "pouchdb-node": "^6.0.4",
     "pouchdb-server": "~1.2.0",
     "supertest": "2.0.0"
   },


### PR DESCRIPTION
depends on #375, closes #274 

This PR includes a breaking change. If your app used the leveldb adapter (or another adapter that stores files) and you have database names containing `/`, then your app won’t be able to find the existing databases, as they are in folders like `user%2Fabc4567` instead of nested folders like `user/abc4567`. To migrate, look into the folder where you save your databases into and rename all database folders accordingly

This PR includes a workaround for https://github.com/pouchdb/pouchdb/issues/5668