### PR TITLE
(#407) - remove pouchdb-node from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "memdown": "^1.2.1",
     "mocha": "^3.1.2",
     "pouchdb": "^6.0.4",
-    "pouchdb-node": "^6.0.4",
     "pouchdb-server": "^1.2.0",
     "supertest": "^2.0.0"
   },


### PR DESCRIPTION
We don't need both `pouchdb` and `pouchdb-node`