### PR TITLE
correctly escape filenames

### DIFF
--- a/lib/clean-filename.js
+++ b/lib/clean-filename.js
@@ -1,8 +1,11 @@
+'use strict';
+
 var sanitize = require('sanitize-filename');
 
 function cleanFilename(name) {
-  // some windows reserved names like 'con' and 'prn' return an empty string here,
-  // so just wrap them in double underscores so it's at least something
+  // some windows reserved names like 'con' and 'prn'
+  // return an empty string here, so just wrap them in
+  // double underscores so it's at least something
   return sanitize(name) || sanitize('__' + name + '__');
 }
 

--- a/lib/clean-filename.js
+++ b/lib/clean-filename.js
@@ -1,0 +1,9 @@
+var sanitize = require('sanitize-filename');
+
+function cleanFilename(name) {
+  // some windows reserved names like 'con' and 'prn' return an empty string here,
+  // so just wrap them in double underscores so it's at least something
+  return sanitize(name) || sanitize('__' + name + '__');
+}
+
+module.exports = cleanFilename;

--- a/lib/routes/db.js
+++ b/lib/routes/db.js
@@ -1,16 +1,16 @@
 "use strict";
 
-var startTime   = new Date().getTime(),
-    utils       = require('../utils'),
-    wrappers    = require('pouchdb-wrappers'),
-    mkdirp      = require('mkdirp'),
-    pathResolve = require('path').resolve,
-    sanitize    = require('sanitize-filename');
+var startTime     = new Date().getTime(),
+    utils         = require('../utils'),
+    wrappers      = require('pouchdb-wrappers'),
+    mkdirp        = require('mkdirp'),
+    pathResolve   = require('path').resolve,
+    cleanFilename = require('../clean-filename');
 
 module.exports = function (app) {
   // Create a database.
   app.put('/:db', utils.jsonParser, function (req, res, next) {
-    var name = sanitize(req.params.db);
+    var name = cleanFilename(req.params.db);
 
     req.PouchDB.allDbs(function (err, dbs) {
       if (err) {
@@ -73,7 +73,7 @@ module.exports = function (app) {
         )
       });
     }
-    var name = sanitize(req.params.db);
+    var name = cleanFilename(req.params.db);
     req.PouchDB.destroy(name, utils.makeOpts(req), function (err, info) {
       if (err) {
         return utils.sendError(res, err);

--- a/lib/routes/db.js
+++ b/lib/routes/db.js
@@ -4,12 +4,13 @@ var startTime   = new Date().getTime(),
     utils       = require('../utils'),
     wrappers    = require('pouchdb-wrappers'),
     mkdirp      = require('mkdirp'),
-    pathResolve = require('path').resolve;
+    pathResolve = require('path').resolve,
+    sanitize    = require('sanitize-filename');
 
 module.exports = function (app) {
   // Create a database.
   app.put('/:db', utils.jsonParser, function (req, res, next) {
-    var name = req.params.db;
+    var name = sanitize(req.params.db);
 
     req.PouchDB.allDbs(function (err, dbs) {
       if (err) {
@@ -72,7 +73,7 @@ module.exports = function (app) {
         )
       });
     }
-    var name = req.params.db;
+    var name = sanitize(req.params.db);
     req.PouchDB.destroy(name, utils.makeOpts(req), function (err, info) {
       if (err) {
         return utils.sendError(res, err);

--- a/lib/routes/rewrite.js
+++ b/lib/routes/rewrite.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 var REGEX = /\/([^\/]*)\/_design\/([^\/]*)\/_rewrite\/([^?]*)/;
-var sanitize = require('sanitize-filename');
+var cleanFilename = require('../clean-filename');
 
 module.exports = function (app) {
   utils.requires(app, 'routes/db');
@@ -32,7 +32,7 @@ module.exports = function (app) {
       });
     }
 
-    var dbName = sanitize(decodeURIComponent(match[1]));
+    var dbName = cleanFilename(decodeURIComponent(match[1]));
     utils.setDBOnReq(dbName, app.dbWrapper, req, res, function () {
       var query = match[2] + "/" + match[3];
       var opts = utils.expressReqToCouchDBReq(req);

--- a/lib/routes/rewrite.js
+++ b/lib/routes/rewrite.js
@@ -2,6 +2,7 @@
 
 var utils = require('../utils');
 var REGEX = /\/([^\/]*)\/_design\/([^\/]*)\/_rewrite\/([^?]*)/;
+var sanitize = require('sanitize-filename');
 
 module.exports = function (app) {
   utils.requires(app, 'routes/db');
@@ -31,7 +32,7 @@ module.exports = function (app) {
       });
     }
 
-    var dbName = decodeURIComponent(match[1]);
+    var dbName = sanitize(decodeURIComponent(match[1]));
     utils.setDBOnReq(dbName, app.dbWrapper, req, res, function () {
       var query = match[2] + "/" + match[3];
       var opts = utils.expressReqToCouchDBReq(req);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ var pathResolve = require('path').resolve;
 var rawBody = require('raw-body');
 var Promise = require('pouchdb-promise');
 var mkdirp = require('mkdirp');
+var sanitize = require('sanitize-filename');
 
 //shared middleware
 
@@ -62,6 +63,7 @@ exports.makeOpts = function (req, startOpts) {
 };
 
 exports.setDBOnReq = function (dbName, dbWrapper, req, res, next) {
+  dbName = sanitize(dbName);
   req.PouchDB.allDbs(function (err, dbs) {
     if (err) {
       return exports.sendError(res, err);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@ var pathResolve = require('path').resolve;
 var rawBody = require('raw-body');
 var Promise = require('pouchdb-promise');
 var mkdirp = require('mkdirp');
-var sanitize = require('sanitize-filename');
+var cleanFilename = require('./clean-filename');
 
 //shared middleware
 
@@ -63,7 +63,7 @@ exports.makeOpts = function (req, startOpts) {
 };
 
 exports.setDBOnReq = function (dbName, dbWrapper, req, res, next) {
-  dbName = sanitize(dbName);
+  dbName = cleanFilename(dbName);
   req.PouchDB.allDbs(function (err, dbs) {
     if (err) {
       return exports.sendError(res, err);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "pouchdb-vhost": "^1.0.2",
     "pouchdb-wrappers": "^1.3.6",
     "raw-body": "^2.1.7",
+    "sanitize-filename": "^1.6.1",
     "uuid": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
pouchdb-server's sqlite tests were failing because of this. I think this is a non-breaking change because if users provided a db with a name like `foo/bar` it would just break, whereas after this change it will be a usable db name like `foobar`.