### PR TITLE
(#417) - include id in all bulk_docs results

### DIFF
--- a/lib/routes/bulk-docs.js
+++ b/lib/routes/bulk-docs.js
@@ -35,6 +35,7 @@ module.exports = function (app) {
       utils.sendJSON(res, 201, response.map(function (info) {
         if (info.error) {
           return {
+            id: info.id,
             error: info.name,
             reason: info.message
           };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jshint": "2.8.0",
     "memdown": "^1.2.1",
     "mocha": "^3.1.2",
-    "pouchdb": "^6.0.4",
+    "pouchdb": "^6.1.1",
     "pouchdb-server": "^2.0.1",
     "supertest": "^2.0.0"
   },


### PR DESCRIPTION
This also updates the pouchdb dependency to version 6.1.1 and makes the
tests pass with it.